### PR TITLE
Add developer cache cleanup and easier folder access

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 <p align="center">
   chippytea is an ultra-performant, native macOS app that clears space on your Mac.
-  Built with SwiftUI and Rust, it helps you find old build folders, project dependencies
-  and installers you may no longer need. Review their estimated sizes, see what removing
+  Built with SwiftUI and Rust, it helps you find app caches, developer tools, old build folders
+  and downloads you may no longer need. Review their estimated sizes, see what removing
   them means, and choose what to keep or remove.<br>
   SwiftUI + Rust · macOS 14+ · Free and open source
 </p>
@@ -35,13 +35,17 @@ chippytea runs locally from your menu bar. No account, no telemetry, no automati
 
 ## How it works
 
-1. **Find cleanup opportunities.** Scan folders you choose, or use the guided home-folder scan for old app caches, logs, Xcode data, build folders, downloads and large personal files.
+1. **Find cleanup opportunities.** Scan folders you choose, or use **Scan my Mac** for app and developer caches, logs, Xcode data, Python bytecode, build folders, downloads and large personal files. It also checks known system and tool-managed storage locations automatically.
 2. **Check before you clean.** Review the files, estimated size, and consequences. Git and activity checks vary by category; personal files and caches without an identified owning app still need your judgment.
-3. **Choose what to remove.** Move files to Trash, or permanently remove eligible build files and dependencies. Review the outcome and any credited space in the cleanup history.
+3. **Choose what to remove.** Move files to Trash, or permanently remove eligible developer caches, build files and dependencies. Review the outcome and any credited space in the cleanup history.
 
 **Check duplicate files** compares already-indexed old/large personal-file suggestions when you ask. It verifies contents, lets you choose one copy to keep and one to review, and rechecks both before moving the selected copy to Trash. This is a bounded check, not a whole-Mac duplicate search; ordinary scans never hash personal-file contents.
 
-Moving files to **Trash does not free storage**. App caches, logs, Xcode DerivedData, downloads and personal files are review/Trash-only; they never earn chips. Permanent cleanup is limited to verified, eligible developer build files and dependencies.
+Moving files to **Trash does not free storage**. App caches, logs, Python bytecode, Xcode DerivedData, downloads and personal files are review/Trash-only; they never earn chips. Verified developer caches, build files and dependencies can be deleted permanently after their ownership, activity and contents are rechecked.
+
+Known npm, npx, Corepack, Bun, pip, uv, mise, Cargo, SwiftPM, Zig, Expo, Homebrew download and AWS CLI caches appear in the same cleanup list, with the same checkboxes and review action. Only recognized cache directories are eligible; active tools, shared files and unrelated configuration stay protected. Blocked caches stay in the list with their reason and cleanup disabled. Installed toolchains, container data and system locations appear alongside cleanup findings with their relevant review steps. Their measured size does not establish how much is removable; some system locations need administrator access.
+
+Use **Settings → Scan locations & access** to add a folder or mounted drive, reconnect an unavailable location, or redo access setup. Saved volume identities handle macOS device-number changes without renewing a valid folder grant. Older grants that are already invalid need one explicit reconnection; Keep choices and cleanup history are preserved.
 
 This is early software that can permanently delete files. Start with a disposable test folder and keep backups. Full Disk Access is optional.
 

--- a/core/src/activity.rs
+++ b/core/src/activity.rs
@@ -22,15 +22,164 @@ const MAX_BUNDLE_IDENTIFIER_BYTES: usize = 1024;
 const BUNDLE_ACTIVITY_LIMIT: &str =
     "Running application ownership exceeded its bounded activity check; cleanup is withheld";
 
+#[derive(Clone)]
 pub(crate) struct ActivitySnapshot {
     pub(crate) working_directories: Vec<PathBuf>,
     pub(crate) executable_paths: Vec<PathBuf>,
     pub(crate) running_app_bundle_ids: OnceCell<Result<BTreeSet<String>>>,
 }
 
+#[cfg(test)]
+thread_local! {
+    static TEST_ACTIVITY: std::cell::RefCell<Option<Result<ActivitySnapshot>>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Scoped, thread-local process snapshots keep destructive fixture checks
+/// independent of unrelated host applications. This hook is absent from every
+/// production and integration-test library build.
+#[cfg(test)]
+pub(crate) fn with_test_snapshot<T>(
+    snapshot: Result<ActivitySnapshot>,
+    run: impl FnOnce() -> T,
+) -> T {
+    struct Restore(Option<Result<ActivitySnapshot>>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            TEST_ACTIVITY.with(|value| *value.borrow_mut() = self.0.take());
+        }
+    }
+    let _restore = Restore(TEST_ACTIVITY.with(|value| value.replace(Some(snapshot))));
+    run()
+}
+
+#[cfg(test)]
+pub(crate) fn test_snapshot(
+    executables: &[&str],
+    working_directories: Vec<PathBuf>,
+) -> ActivitySnapshot {
+    ActivitySnapshot {
+        working_directories,
+        executable_paths: executables.iter().map(PathBuf::from).collect(),
+        running_app_bundle_ids: OnceCell::from(Ok(BTreeSet::new())),
+    }
+}
+
+fn python_interpreter(name: &str) -> bool {
+    if matches!(name, "python" | "Python") {
+        return true;
+    }
+    name.strip_prefix("python").is_some_and(|version| {
+        let version = version.strip_suffix('t').unwrap_or(version);
+        !version.is_empty()
+            && version.bytes().any(|byte| byte.is_ascii_digit())
+            && version
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || byte == b'.')
+    })
+}
+
+/// Exact generated-cache routes have known writers even when their process
+/// cwd and installed executable live elsewhere. Do not inspect arguments or
+/// guess which global process currently references an individual cache.
+fn tool_cache_writer(location: &Path, executable: &str) -> bool {
+    if !matches!(
+        executable,
+        "zig" | "ruff" | "mypy" | "opencode" | "ghostty" | "zsh" | "node" | "bun"
+    ) && !python_interpreter(executable)
+    {
+        return false;
+    }
+    if location.ends_with(".cache/zig") {
+        return executable == "zig";
+    }
+    if location.ends_with(".cache/ruff") {
+        return executable == "ruff";
+    }
+    if location.ends_with(".cache/mypy") {
+        return executable == "mypy" || python_interpreter(executable);
+    }
+    if location.ends_with(".cache/opencode") {
+        return matches!(executable, "opencode" | "bun");
+    }
+    if location.ends_with(".cache/ghostty") {
+        return executable == "ghostty";
+    }
+    if location.ends_with(".oh-my-zsh/cache") {
+        return executable == "zsh";
+    }
+    [
+        ".cache/typescript",
+        ".cache/eslint",
+        ".cache/prettier",
+        ".expo/native-modules-cache",
+        ".expo/versions-cache",
+        ".expo/schema-cache",
+        ".expo/template-cache",
+    ]
+    .iter()
+    .any(|route| location.ends_with(route))
+        && matches!(executable, "node" | "bun")
+}
+
+fn developer_cache_writer(location: &Path, executable: &str) -> bool {
+    let Some(route) = crate::recommendations::DEVELOPER_CACHE_ROUTES
+        .iter()
+        .find(|route| location.ends_with(route.path))
+    else {
+        return false;
+    };
+    match route.owner {
+        "node" => matches!(
+            executable,
+            "node" | "nodejs" | "bun" | "npm" | "npx" | "corepack"
+        ),
+        "bun" => matches!(executable, "bun" | "bunx"),
+        "pip" | "uv" => {
+            python_interpreter(executable)
+                || matches!(executable, "pip" | "pip3" | "uv" | "uvx")
+                || executable.strip_prefix("pip").is_some_and(|version| {
+                    !version.is_empty()
+                        && version
+                            .bytes()
+                            .all(|byte| byte.is_ascii_digit() || byte == b'.')
+                })
+        }
+        "mise" => executable == "mise",
+        "cargo" => matches!(
+            executable,
+            "cargo" | "rustc" | "rustdoc" | "rust-analyzer" | "clippy-driver" | "git"
+        ),
+        "swiftpm" => matches!(
+            executable,
+            "swift"
+                | "swift-build"
+                | "swift-package"
+                | "swift-test"
+                | "swift-run"
+                | "swift-frontend"
+                | "xcodebuild"
+                | "Xcode"
+                | "XCBBuildService"
+                | "SWBBuildService"
+                | "git"
+        ),
+        "homebrew" => matches!(executable, "brew" | "ruby" | "curl" | "wget"),
+        "aws" => executable == "aws" || python_interpreter(executable),
+        "zig" => executable == "zig",
+        "ruff" => executable == "ruff" || python_interpreter(executable),
+        "mypy" => executable == "mypy" || python_interpreter(executable),
+        _ => true,
+    }
+}
+
 impl ActivitySnapshot {
     #[cfg(target_os = "macos")]
     pub(crate) fn capture(cancel: &AtomicBool) -> Result<Self> {
+        #[cfg(test)]
+        if let Some(snapshot) = TEST_ACTIVITY.with(|value| value.borrow().clone()) {
+            safety::cancelled(cancel)?;
+            return snapshot;
+        }
         // Query only this account. Kernel/system services that cannot be inspected
         // are outside the per-user build activity signal, rather than silently
         // treated as known idle processes.
@@ -130,6 +279,11 @@ impl ActivitySnapshot {
 
     #[cfg(not(target_os = "macos"))]
     pub(crate) fn capture(_cancel: &AtomicBool) -> Result<Self> {
+        #[cfg(test)]
+        if let Some(snapshot) = TEST_ACTIVITY.with(|value| value.borrow().clone()) {
+            safety::cancelled(_cancel)?;
+            return snapshot;
+        }
         Err("Reliable activity checks are supported only by the native macOS engine".into())
     }
 
@@ -161,6 +315,19 @@ impl ActivitySnapshot {
         location: &Path,
         cancel: &AtomicBool,
     ) -> Option<String> {
+        if matches!(kind, "pythoncache" | "cache" | "devcache")
+            && self.executable_paths.iter().any(|path| {
+                path.file_name()
+                    .and_then(OsStr::to_str)
+                    .is_some_and(|name| {
+                        (kind == "pythoncache" && python_interpreter(name))
+                            || (kind == "cache" && tool_cache_writer(location, name))
+                            || (kind == "devcache" && developer_cache_writer(location, name))
+                    })
+            })
+        {
+            return Some("A tool that writes this generated cache is running; close it before reviewing cleanup".into());
+        }
         // A global managed host can load project output named only in its
         // arguments or open handles while its cwd is elsewhere. We do not
         // inspect those private arguments or infer which project it uses.
@@ -868,6 +1035,138 @@ mod tests {
                 .blocked_for("cache", Path::new("/cache/terminal-sibling"), &cancel)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn python_and_exact_tool_cache_writers_block_cleanup_outside_their_cwd() {
+        let cancel = AtomicBool::new(false);
+        for executable in ["python", "Python", "python3", "python3.14", "python3.13t"] {
+            let mut active = snapshot(&[]);
+            active.executable_paths = vec![Path::new("/toolchain/bin").join(executable)];
+            assert!(
+                active
+                    .blocked_for(
+                        "pythoncache",
+                        Path::new("/projects/source/__pycache__"),
+                        &cancel
+                    )
+                    .is_some()
+            );
+        }
+        for (executable, cache) in [
+            ("zig", ".cache/zig"),
+            ("ruff", ".cache/ruff"),
+            ("python3.14", ".cache/mypy"),
+            ("opencode", ".cache/opencode"),
+            ("ghostty", ".cache/ghostty"),
+            ("zsh", ".oh-my-zsh/cache"),
+            ("node", ".expo/versions-cache"),
+            ("bun", ".cache/typescript"),
+        ] {
+            let mut active = snapshot(&[]);
+            active.executable_paths = vec![Path::new("/toolchain/bin").join(executable)];
+            assert!(
+                active
+                    .blocked_for("cache", &Path::new("/Users/fixture").join(cache), &cancel)
+                    .is_some(),
+                "{cache}"
+            );
+            assert!(
+                active
+                    .blocked_for(
+                        "cache",
+                        &Path::new("/Users/fixture").join(format!("{cache}-backup")),
+                        &cancel
+                    )
+                    .is_none(),
+                "{cache}"
+            );
+        }
+        assert!(!python_interpreter("python-project"));
+        assert!(!python_interpreter("python.."));
+        assert!(!python_interpreter("python3-malware"));
+        let mut active = snapshot(&[]);
+        active.executable_paths = vec![PathBuf::from("/toolchain/bin/zig")];
+        assert!(
+            active
+                .blocked_for(
+                    "pythoncache",
+                    Path::new("/projects/source/__pycache__"),
+                    &cancel
+                )
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn devcache_owner_processes_are_checked_outside_the_cache_and_near_misses_are_not_owners() {
+        let cancel = AtomicBool::new(false);
+        for (route, executable) in [
+            (".npm/_cacache", "node"),
+            (".npm/_npx", "npm"),
+            (".cache/node/corepack", "nodejs"),
+            (".bun/install/cache", "bun"),
+            ("Library/Caches/pip", "python3.14"),
+            (".cache/pip", "pip3.14"),
+            (".cache/uv", "uv"),
+            ("Library/Caches/uv", "python"),
+            (".cache/mise", "mise"),
+            (".cargo/registry/src", "cargo"),
+            (".cargo/git/db", "git"),
+            ("Library/org.swift.swiftpm/cache", "swift-package"),
+            ("Library/Caches/org.swift.swiftpm", "Xcode"),
+            ("Library/Caches/Homebrew/downloads", "ruby"),
+            (".aws/cli/cache", "aws"),
+            (".cache/zig", "zig"),
+            (".cache/ruff", "ruff"),
+            (".cache/mypy", "python3"),
+            (".expo/template-cache", "node"),
+            (".cache/typescript", "bun"),
+        ] {
+            let active = test_snapshot(&[&format!("/unrelated/tools/{executable}")], vec![]);
+            let cache = Path::new("/Users/fixture").join(route);
+            assert!(
+                active.blocked_for("devcache", &cache, &cancel).is_some(),
+                "{route}: {executable}"
+            );
+            let sibling = cache.with_file_name(format!(
+                "{}-backup",
+                cache.file_name().unwrap().to_string_lossy()
+            ));
+            assert!(
+                active.blocked_for("devcache", &sibling, &cancel).is_none(),
+                "{route}: unrelated sibling"
+            );
+        }
+        let cache = Path::new("/Users/fixture/.npm/_cacache");
+        let active = test_snapshot(&[], vec![cache.join("worker-directory")]);
+        assert!(active.blocked_for("devcache", cache, &cancel).is_some());
+    }
+
+    #[test]
+    fn support_cache_owner_is_limited_to_exact_generated_leaf() {
+        let active = snapshot(&["com.tinyspeck.slackmacgap"]);
+        let cancel = AtomicBool::new(false);
+        assert!(
+            active
+                .blocked_for(
+                    "cache",
+                    Path::new("/Users/fixture/Library/Application Support/Slack/Cache"),
+                    &cancel
+                )
+                .is_some()
+        );
+        for location in [
+            "/Users/fixture/Library/Application Support/Slack/Local Storage",
+            "/Users/fixture/Library/Application Support/Slack/Cache-backup",
+            "/Users/fixture/Library/Application Support/Claude/Cache",
+        ] {
+            assert!(
+                active
+                    .blocked_for("cache", Path::new(location), &cancel)
+                    .is_none()
+            );
+        }
     }
 
     #[test]

--- a/core/src/cleanup.rs
+++ b/core/src/cleanup.rs
@@ -1277,6 +1277,453 @@ mod tests {
         sync::Arc,
     };
 
+    fn devcache_candidates(root: &Root) -> Vec<Candidate> {
+        let mut rows = HashMap::new();
+        scanner::scan(root, None, &AtomicBool::new(false), |batch| {
+            for candidate in batch.candidates {
+                if !candidate.provisional {
+                    rows.insert(candidate.path.clone(), candidate);
+                }
+            }
+        })
+        .unwrap();
+        rows.into_values()
+            .filter(|row| row.kind == "devcache")
+            .collect()
+    }
+
+    fn devcache_fixture(
+        routes: &[&str],
+    ) -> (tempfile::TempDir, Store, Root, Vec<Candidate>, Vec<PathBuf>) {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().canonicalize().unwrap();
+        let home = base.join("Home");
+        for route in routes {
+            let directory = home.join(route);
+            std::fs::create_dir_all(&directory).unwrap();
+            let mut file = File::create(directory.join("payload")).unwrap();
+            file.write_all(&[0x59; 8192]).unwrap();
+            file.sync_all().unwrap();
+        }
+        let preserved: Vec<_> = [
+            ".npmrc",
+            ".cargo/config.toml",
+            ".cargo/bin/tool",
+            ".rustup/toolchains/current/bin/rustc",
+            ".local/share/mise/installs/python/current",
+            ".aws/credentials",
+            ".aws/config",
+            ".expo/state.json",
+            ".bun/bin/bun",
+            "Documents/project/source.rs",
+            "Library/Caches/Homebrew/locks/keep.lock",
+            "Library/org.swift.swiftpm/configuration/settings.json",
+        ]
+        .iter()
+        .map(|path| home.join(path))
+        .collect();
+        for path in &preserved {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"preserve adjacent user data").unwrap();
+        }
+        let root = safety::authorize(&home, "home").unwrap();
+        let rows = devcache_candidates(&root);
+        assert_eq!(rows.len(), routes.len(), "{rows:?}");
+        for row in &rows {
+            assert!(row.suggestion_eligible && row.eligible_permanent, "{row:?}");
+            assert!(row.allocated_bytes >= 4096 && row.file_count == 1);
+            assert!(!row.fingerprint.is_empty());
+        }
+        let store = Store::open(&base.join("ledger.sqlite")).unwrap();
+        (temp, store, root, rows, preserved)
+    }
+
+    #[test]
+    fn devcache_permanent_cleanup_removes_multiple_recent_caches_and_preserves_adjacent_data() {
+        crate::activity::with_test_snapshot(
+            Ok(crate::activity::test_snapshot(&[], vec![])),
+            || {
+                let (_temp, mut store, root, rows, preserved) = devcache_fixture(&[
+                    ".npm/_cacache",
+                    "Library/Caches/pip",
+                    ".cache/uv",
+                    ".cargo/registry/cache",
+                    ".aws/cli/cache",
+                    "Library/org.swift.swiftpm/cache",
+                    "Library/Caches/Homebrew/downloads",
+                ]);
+                let mut credited = 0;
+                for row in &rows {
+                    scanner::revalidate(&root, row, &AtomicBool::new(false)).unwrap();
+                    let receipt = execute(
+                        &mut store,
+                        &root,
+                        row,
+                        "permanent",
+                        None,
+                        &AtomicBool::new(false),
+                    )
+                    .unwrap();
+                    assert_eq!(receipt.outcome, "removed", "{}", receipt.detail);
+                    assert!(!row.path.exists());
+                    assert_eq!(receipt.reported_bytes, row.allocated_bytes);
+                    assert!(
+                        receipt.credited_bytes
+                            <= receipt.observed_bytes.min(receipt.reported_bytes),
+                        "Filesystem deletion must not manufacture APFS space credit"
+                    );
+                    credited += receipt.credited_bytes;
+                    assert!(
+                        execute(
+                            &mut store,
+                            &root,
+                            row,
+                            "permanent",
+                            None,
+                            &AtomicBool::new(false)
+                        )
+                        .is_err(),
+                        "An old candidate cannot be replayed after removal"
+                    );
+                }
+                assert_eq!(store.wallet().unwrap().credited_bytes, credited);
+                for path in preserved {
+                    assert_eq!(std::fs::read(path).unwrap(), b"preserve adjacent user data");
+                }
+            },
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn devcache_trash_preserves_restorable_contents_without_credit() {
+        crate::activity::with_test_snapshot(
+            Ok(crate::activity::test_snapshot(&[], vec![])),
+            || {
+                let (temp, mut store, root, rows, _) = devcache_fixture(&[".cache/uv"]);
+                let destination = temp.path().canonicalize().unwrap().join("fixture-trash");
+                let _trash = install_fake_trash(destination.clone());
+                let receipt = execute(
+                    &mut store,
+                    &root,
+                    &rows[0],
+                    "trash",
+                    Some(fake_trash),
+                    &AtomicBool::new(false),
+                )
+                .unwrap();
+                assert_eq!(receipt.outcome, "trashed", "{}", receipt.detail);
+                assert_eq!(fake_trash_calls(), 1);
+                assert!(!rows[0].path.exists());
+                assert_eq!(
+                    std::fs::read(destination.join("payload")).unwrap(),
+                    [0x59; 8192]
+                );
+                assert_eq!(store.wallet().unwrap().credited_bytes, 0);
+                assert!(receipt.can_restore);
+            },
+        );
+    }
+
+    #[test]
+    fn devcache_active_writers_block_discovery_and_previously_reviewed_cleanup() {
+        for (route, executable) in [
+            (".npm/_cacache", "/tools/node"),
+            (".cache/uv", "/tools/python3.14"),
+            (".cargo/registry/cache", "/tools/cargo"),
+            ("Library/Caches/Homebrew/downloads", "/tools/curl"),
+            (".aws/cli/cache", "/tools/aws"),
+        ] {
+            crate::activity::with_test_snapshot(
+                Ok(crate::activity::test_snapshot(&[], vec![])),
+                || {
+                    let (_temp, mut store, root, rows, _) = devcache_fixture(&[route]);
+                    crate::activity::with_test_snapshot(
+                        Ok(crate::activity::test_snapshot(&[executable], vec![])),
+                        || {
+                            let active = devcache_candidates(&root);
+                            assert_eq!(active.len(), 1);
+                            assert!(
+                                !active[0].suggestion_eligible && !active[0].eligible_permanent
+                            );
+                            assert!(
+                                active[0]
+                                    .blocked_reason
+                                    .as_deref()
+                                    .unwrap()
+                                    .contains("running")
+                            );
+                            let receipt = execute(
+                                &mut store,
+                                &root,
+                                &rows[0],
+                                "permanent",
+                                None,
+                                &AtomicBool::new(false),
+                            )
+                            .unwrap();
+                            assert_eq!(receipt.outcome, "skipped", "{}", receipt.detail);
+                            assert_eq!(
+                                std::fs::read(rows[0].path.join("payload")).unwrap(),
+                                [0x59; 8192]
+                            );
+                            assert_eq!(store.wallet().unwrap().credited_bytes, 0);
+                        },
+                    );
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn devcache_revalidation_refuses_replacement_new_files_wrong_kind_and_non_home_grants() {
+        for mutation in [
+            "replacement",
+            "new-file",
+            "wrong-kind",
+            "wrong-grant",
+            "external-hardlink",
+        ] {
+            crate::activity::with_test_snapshot(
+                Ok(crate::activity::test_snapshot(&[], vec![])),
+                || {
+                    let (temp, mut store, root, mut rows, _) = devcache_fixture(&[".npm/_cacache"]);
+                    let row = &mut rows[0];
+                    let saved = temp.path().canonicalize().unwrap().join("saved-original");
+                    let mut grant = root.clone();
+                    match mutation {
+                        "replacement" => {
+                            std::fs::rename(&row.path, &saved).unwrap();
+                            std::fs::create_dir(&row.path).unwrap();
+                            std::fs::write(row.path.join("payload"), b"new replacement contents")
+                                .unwrap();
+                        }
+                        "new-file" => std::fs::write(
+                            row.path.join("new-source.txt"),
+                            b"preserve new contents",
+                        )
+                        .unwrap(),
+                        "wrong-kind" => row.kind = "cargo".into(),
+                        "wrong-grant" => grant.kind = "projects".into(),
+                        "external-hardlink" => {
+                            std::fs::hard_link(row.path.join("payload"), &saved).unwrap()
+                        }
+                        _ => unreachable!(),
+                    }
+                    assert!(
+                        scanner::revalidate(&grant, row, &AtomicBool::new(false)).is_err(),
+                        "{mutation}"
+                    );
+                    let result = execute(
+                        &mut store,
+                        &grant,
+                        row,
+                        "permanent",
+                        None,
+                        &AtomicBool::new(false),
+                    );
+                    assert!(
+                        match &result {
+                            Err(_) => true,
+                            Ok(receipt) => receipt.outcome == "skipped",
+                        },
+                        "{mutation}: {result:?}"
+                    );
+                    assert!(row.path.join("payload").exists(), "{mutation}");
+                    assert_eq!(store.wallet().unwrap().credited_bytes, 0);
+                    if mutation == "replacement" {
+                        assert_eq!(std::fs::read(saved.join("payload")).unwrap(), [0x59; 8192]);
+                    }
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn devcache_shared_links_git_and_symlink_boundaries_never_become_cleanup() {
+        crate::activity::with_test_snapshot(
+            Ok(crate::activity::test_snapshot(&[], vec![])),
+            || {
+                let (_temp, _store, root, rows, _) =
+                    devcache_fixture(&[".npm/_cacache", ".cache/uv"]);
+                std::fs::hard_link(rows[0].path.join("payload"), rows[1].path.join("shared"))
+                    .unwrap();
+                let shared = devcache_candidates(&root);
+                assert_eq!(shared.len(), 2);
+                assert!(
+                    shared
+                        .iter()
+                        .all(|row| !row.suggestion_eligible && !row.eligible_permanent)
+                );
+                for row in shared {
+                    assert!(row.path.join("payload").exists());
+                }
+            },
+        );
+        for boundary in ["git", "symlink-root", "protected-git-child"] {
+            crate::activity::with_test_snapshot(
+                Ok(crate::activity::test_snapshot(&[], vec![])),
+                || {
+                    let (temp, _store, root, rows, _) = devcache_fixture(&[".npm/_cacache"]);
+                    if boundary == "git" {
+                        for arguments in [vec!["init", "-q"], vec!["add", ".npm/_cacache/payload"]]
+                        {
+                            assert!(
+                                std::process::Command::new("/usr/bin/git")
+                                    .env_clear()
+                                    .env("PATH", "/usr/bin:/bin")
+                                    .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                                    .env("GIT_CONFIG_NOSYSTEM", "1")
+                                    .args(arguments)
+                                    .current_dir(&root.path)
+                                    .status()
+                                    .unwrap()
+                                    .success()
+                            );
+                        }
+                    } else if boundary == "protected-git-child" {
+                        std::fs::create_dir(rows[0].path.join(".git")).unwrap();
+                        std::fs::write(
+                            rows[0].path.join(".git/config"),
+                            b"preserve repository metadata",
+                        )
+                        .unwrap();
+                    } else {
+                        let saved = temp.path().canonicalize().unwrap().join("saved-cache");
+                        std::fs::rename(&rows[0].path, &saved).unwrap();
+                        std::os::unix::fs::symlink(saved, &rows[0].path).unwrap();
+                    }
+                    let found = devcache_candidates(&root);
+                    assert!(
+                        found
+                            .iter()
+                            .all(|row| !row.suggestion_eligible && !row.eligible_permanent),
+                        "{boundary}: {found:?}"
+                    );
+                    assert_eq!(
+                        std::fs::read(rows[0].path.join("payload")).unwrap(),
+                        [0x59; 8192]
+                    );
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn devcache_npx_bin_links_and_uv_internal_archives_are_deleted_without_following_links() {
+        crate::activity::with_test_snapshot(
+            Ok(crate::activity::test_snapshot(&[], vec![])),
+            || {
+                let (_temp, mut store, root, _rows, preserved) =
+                    devcache_fixture(&[".npm/_npx", ".cache/uv"]);
+                let npx = root.path.join(".npm/_npx");
+                let uv = root.path.join(".cache/uv");
+                let package = npx.join("install-hash/node_modules/fixture-cli");
+                std::fs::create_dir_all(&package).unwrap();
+                std::fs::write(
+                    package.join("package.json"),
+                    br#"{"name":"fixture-cli","bin":{"fixture":"cli.js"}}"#,
+                )
+                .unwrap();
+                std::fs::write(
+                    package.join("cli.js"),
+                    b"#!/usr/bin/env node\nconsole.log('fixture');\n",
+                )
+                .unwrap();
+                let bin = package.parent().unwrap().join(".bin");
+                std::fs::create_dir(&bin).unwrap();
+                std::os::unix::fs::symlink("../fixture-cli/cli.js", bin.join("fixture")).unwrap();
+                // The outside link target is preserved. Developer policy captures
+                // the link identity and unlinks only that leaf; it never opens it.
+                std::os::unix::fs::symlink(&preserved[0], package.join("external-reference"))
+                    .unwrap();
+                let archive = uv.join("archive-v0/fixture-hash/package");
+                let wheel = uv.join("wheels-v5/default/fixture-package");
+                std::fs::create_dir_all(&archive).unwrap();
+                std::fs::create_dir_all(&wheel).unwrap();
+                std::fs::rename(uv.join("payload"), archive.join("module.py")).unwrap();
+                std::fs::hard_link(archive.join("module.py"), archive.join("module-copy.py"))
+                    .unwrap();
+                std::os::unix::fs::symlink(
+                    "../../../archive-v0/fixture-hash",
+                    wheel.join("1.0-py3-none-any"),
+                )
+                .unwrap();
+                let rows = devcache_candidates(&root);
+                assert_eq!(rows.len(), 2);
+                for row in rows {
+                    assert!(row.suggestion_eligible && row.eligible_permanent, "{row:?}");
+                    let receipt = execute(
+                        &mut store,
+                        &root,
+                        &row,
+                        "permanent",
+                        None,
+                        &AtomicBool::new(false),
+                    )
+                    .unwrap();
+                    assert_eq!(receipt.outcome, "removed", "{}", receipt.detail);
+                    assert!(!row.path.exists());
+                }
+                for path in preserved {
+                    assert_eq!(std::fs::read(path).unwrap(), b"preserve adjacent user data");
+                }
+            },
+        );
+        crate::activity::with_test_snapshot(
+            Ok(crate::activity::test_snapshot(&[], vec![])),
+            || {
+                let (_temp, _store, root, rows, _) = devcache_fixture(&[".cache/uv"]);
+                let installed = root
+                    .path
+                    .join("Documents/project/.venv/lib/fixture/module.py");
+                std::fs::create_dir_all(installed.parent().unwrap()).unwrap();
+                std::fs::hard_link(rows[0].path.join("payload"), &installed).unwrap();
+                let rows = devcache_candidates(&root);
+                assert_eq!(rows.len(), 1);
+                assert!(!rows[0].suggestion_eligible && !rows[0].eligible_permanent);
+                assert_eq!(std::fs::read(installed).unwrap(), [0x59; 8192]);
+            },
+        );
+    }
+
+    #[test]
+    fn devcache_unknown_process_activity_never_authorizes_a_previous_review() {
+        crate::activity::with_test_snapshot(
+            Ok(crate::activity::test_snapshot(&[], vec![])),
+            || {
+                let (_temp, mut store, root, rows, _) = devcache_fixture(&[".npm/_cacache"]);
+                crate::activity::with_test_snapshot(
+                    Err("Unidentified process fixture".into()),
+                    || {
+                        let current = devcache_candidates(&root);
+                        assert_eq!(current.len(), 1);
+                        assert!(!current[0].suggestion_eligible && !current[0].eligible_permanent);
+                        assert_eq!(
+                            current[0].blocked_reason.as_deref(),
+                            Some("Unidentified process fixture")
+                        );
+                        let receipt = execute(
+                            &mut store,
+                            &root,
+                            &rows[0],
+                            "permanent",
+                            None,
+                            &AtomicBool::new(false),
+                        )
+                        .unwrap();
+                        assert_eq!(receipt.outcome, "skipped");
+                        assert_eq!(
+                            std::fs::read(rows[0].path.join("payload")).unwrap(),
+                            [0x59; 8192]
+                        );
+                        assert_eq!(store.wallet().unwrap().credited_bytes, 0);
+                    },
+                );
+            },
+        );
+    }
+
     struct RestoreFixture {
         store: Store,
         candidate: Candidate,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod safety;
 #[doc(hidden)]
 pub mod scan_worker;
 pub mod scanner;
+mod storage_inventory;
 pub mod store;
 
 use model::*;
@@ -312,6 +313,7 @@ pub struct Engine {
     checking_duplicates: AtomicBool,
     duplicate_cancel: AtomicBool,
     managed_review: Mutex<ManagedReviewState>,
+    storage_inventory: Mutex<()>,
     sql_interrupt: rusqlite::InterruptHandle,
     busy: AtomicBool,
     scanning: AtomicBool,
@@ -357,6 +359,27 @@ impl Engine {
         }
         let mut store = Store::open(path)?;
         store.reconcile()?;
+        // Device numbers may change when macOS remounts an APFS volume. Only
+        // a previously captured durable identity can renew such a grant. This
+        // happens before any worker or review exists and atomically discards
+        // its old findings; missing/replaced/legacy-unverified roots stay closed.
+        for root in store.roots()? {
+            if let Some(anchor) = store.root_anchor(&root.id)? {
+                if let Ok(Some(current)) = safety::rebind_root(&root, &anchor) {
+                    // Renewal is opportunistic. A grant conflict or failed
+                    // transaction must leave the old grant available to the
+                    // Settings repair flow instead of preventing app startup.
+                    let _ = store.reauthorize_root(&current, &root.id, Some(&anchor));
+                }
+            } else if let Ok((current, Some(anchor))) =
+                safety::authorize_with_anchor(&root.path, &root.kind)
+                && safety::same_object(&root.identity, &current.identity)
+            {
+                // Upgrade a still-valid legacy grant without changing its
+                // authority or accepting an already-different device number.
+                store.save_root_anchor(&root.id, &anchor)?;
+            }
+        }
         // The library is exclusively owned and no reviews exist during open.
         // Keep migration work bounded; admission prevents further growth even
         // when a legacy index needs more than one idle maintenance slice.
@@ -385,6 +408,7 @@ impl Engine {
             checking_duplicates: AtomicBool::new(false),
             duplicate_cancel: AtomicBool::new(false),
             managed_review: Mutex::new(ManagedReviewState::default()),
+            storage_inventory: Mutex::new(()),
             sql_interrupt,
             busy: AtomicBool::new(false),
             scanning: AtomicBool::new(false),
@@ -589,11 +613,52 @@ impl Engine {
                 Ok(json!({"ok":true}))
             }
             "prepare_duplicate" => self.prepare_duplicate(&request),
-            "authorize" => {
+            "storage_inventory" => {
+                let _inventory = self
+                    .storage_inventory
+                    .try_lock()
+                    .map_err(|_| "A storage overview is already running.")?;
+                let root = self
+                    .store
+                    .lock()
+                    .map_err(store::err)?
+                    .root(string(&request, "root_id")?)?;
+                if root.kind != "home" {
+                    return Err(
+                        "Set up Scan my Mac before checking system and developer storage.".into(),
+                    );
+                }
+                safety::validate_root(&root)?;
+                // A fixture Home can exercise the exact user routes without
+                // touching real system locations. Callers cannot supply a
+                // second arbitrary path or select their own system routes.
+                let include_system =
+                    std::env::var_os("HOME").is_some_and(|home| Path::new(&home) == root.path);
+                let report = storage_inventory::scan(&root, include_system);
+                safety::validate_root(&root)?;
+                if !self
+                    .store
+                    .lock()
+                    .map_err(store::err)?
+                    .root(&root.id)
+                    .is_ok_and(|current| same_root(&current, &root))
+                {
+                    return Err(
+                        "Scan access changed during the storage overview. Scan again.".into(),
+                    );
+                }
+                serde_json::to_value(report).map_err(store::err)
+            }
+            "root_access" => {
+                let roots = self.store.lock().map_err(store::err)?.roots()?;
+                serde_json::to_value(roots.iter().map(safety::root_access).collect::<Vec<_>>())
+                    .map_err(store::err)
+            }
+            "authorize" | "reauthorize" => {
                 if self.busy.load(Ordering::Acquire) {
                     return Err("Wait for the current operation before adding a folder.".into());
                 }
-                let root = safety::authorize(
+                let (root, anchor) = safety::authorize_with_anchor(
                     Path::new(string(&request, "path")?),
                     string(&request, "kind")?,
                 )?;
@@ -606,13 +671,20 @@ impl Engine {
                 if self.busy.load(Ordering::Acquire) {
                     return Err("Wait for the current operation before adding a folder.".into());
                 }
-                self.store
-                    .lock()
-                    .map_err(store::err)?
-                    .authorize_root(&root, replace_contained)?;
+                let mut reviews = self.reviews.lock().map_err(store::err)?;
+                let mut store = self.store.lock().map_err(store::err)?;
+                if request.get("action").and_then(Value::as_str) == Some("reauthorize") {
+                    store.reauthorize_root(&root, string(&request, "id")?, anchor.as_ref())?;
+                } else {
+                    store.authorize_root_with_anchor(&root, replace_contained, anchor.as_ref())?;
+                }
+                drop(store);
+                reviews.clear();
+                drop(reviews);
                 runtime.recent_files.clear();
                 runtime.foreground = None;
                 runtime.restored_foreground = None;
+                runtime.error = None;
                 self.invalidate_duplicates(None, None);
                 serde_json::to_value(root).map_err(store::err)
             }
@@ -625,10 +697,17 @@ impl Engine {
                 if self.busy.load(Ordering::Acquire) {
                     return Err("Cancel the current operation before removing a folder.".into());
                 }
-                if self.store.lock().map_err(store::err)?.remove_root(id)? {
+                let mut reviews = self.reviews.lock().map_err(store::err)?;
+                let removed = self.store.lock().map_err(store::err)?.remove_root(id)?;
+                if removed {
+                    reviews.clear();
+                }
+                drop(reviews);
+                if removed {
                     runtime.recent_files.clear();
                     runtime.foreground = None;
                     runtime.restored_foreground = None;
+                    runtime.error = None;
                     self.invalidate_duplicates(Some(id), None);
                 }
                 Ok(json!({"ok":true}))
@@ -1035,7 +1114,9 @@ impl Engine {
                         if self.mutation_cancel.load(Ordering::Acquire) {
                             break;
                         }
-                        if s.root(&root.id).is_err()
+                        if !s
+                            .root(&root.id)
+                            .is_ok_and(|current| same_root(&current, &root))
                             || s.kept()?.iter().any(|path| {
                                 candidate.path.starts_with(path)
                                     || Path::new(path).starts_with(&candidate.path)
@@ -5670,6 +5751,241 @@ mod controller_tests {
                 fs::rename(moved, &roots[0].path).unwrap();
             }
         }
+    }
+
+    #[test]
+    fn storage_overview_requires_a_home_grant_and_never_creates_cleanup_state() {
+        let (temp, engine, roots) = foreground_fixture(1);
+        let folder = &roots[0];
+        assert!(
+            engine
+                .request(json!({"action":"storage_inventory","root_id":folder.id}))
+                .is_err()
+        );
+        assert!(
+            engine
+                .request(json!({"action":"storage_inventory","root_id":"missing"}))
+                .is_err()
+        );
+        let home = temp.path().canonicalize().unwrap().join("inventory-home");
+        let toolchain = home.join(".rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc");
+        fs::create_dir_all(toolchain.parent().unwrap()).unwrap();
+        fs::write(&toolchain, b"installed toolchain bytes").unwrap();
+        let cache_paths = [
+            ".npm/_cacache/preserved",
+            ".cargo/registry/cache/preserved",
+            "Library/Caches/Homebrew/downloads/preserved",
+            "Library/org.swift.swiftpm/cache/preserved",
+            "Library/Logs/com.example.app/preserved.log",
+        ];
+        for path in cache_paths {
+            let path = home.join(path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"cached package bytes").unwrap();
+        }
+        let authorized: Root = serde_json::from_value(
+            engine
+                .request(json!({
+                    "action":"authorize", "path":home, "kind":"home"
+                }))
+                .unwrap(),
+        )
+        .unwrap();
+        let report = engine
+            .request(json!({"action":"storage_inventory","root_id":authorized.id}))
+            .unwrap();
+        assert_eq!(report["rows"].as_array().unwrap().len(), 1);
+        assert_eq!(report["rows"][0]["id"], "rust-toolchains");
+        assert_eq!(report["rows"][0]["cleanup_authority"], "ReviewOnly");
+        assert_eq!(report["examined_entries"], 4);
+        assert!(report["rows"].as_array().unwrap().iter().all(|row| {
+            row["path"]
+                .as_str()
+                .is_some_and(|path| Path::new(path).starts_with(&home))
+        }));
+        assert!(engine.reviews.lock().unwrap().is_empty());
+        assert!(engine.store.lock().unwrap().history().unwrap().is_empty());
+        assert_eq!(
+            engine
+                .store
+                .lock()
+                .unwrap()
+                .wallet()
+                .unwrap()
+                .credited_bytes,
+            0
+        );
+        assert_eq!(fs::read(toolchain).unwrap(), b"installed toolchain bytes");
+        for path in cache_paths {
+            assert_eq!(fs::read(home.join(path)).unwrap(), b"cached package bytes");
+        }
+    }
+
+    #[test]
+    fn explicit_reauthorization_replaces_an_unavailable_grant_and_clears_reviews() {
+        let (temp, engine, roots) = foreground_fixture(1);
+        let previous = &roots[0];
+        let candidate = indexed_fixture_source(previous, "old");
+        let moved = temp.path().join("preserved-grant");
+        fs::rename(&previous.path, &moved).unwrap();
+        fs::create_dir(&previous.path).unwrap();
+        let access = engine.request(json!({"action":"root_access"})).unwrap();
+        assert_eq!(access[0]["status"], "reauthorization_required");
+        assert_eq!(access[0]["root_id"], previous.id);
+        engine.reviews.lock().unwrap().insert(
+            "old-review".into(),
+            Review {
+                operation: "trash".into(),
+                items: vec![(previous.clone(), candidate)],
+                created: now(),
+                cancel_generation: 0,
+                duplicate_keeper: None,
+                duplicate_created: None,
+            },
+        );
+        assert!(
+            engine
+                .request(
+                    json!({"action":"reauthorize","id":previous.id,"path":moved,"kind":"folder"})
+                )
+                .is_err()
+        );
+        assert_eq!(engine.reviews.lock().unwrap().len(), 1);
+        let renewed: Root = serde_json::from_value(
+            engine
+                .request(json!({
+                    "action":"reauthorize","id":previous.id,"path":previous.path,"kind":"folder"
+                }))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_ne!(renewed.id, previous.id);
+        assert!(engine.reviews.lock().unwrap().is_empty());
+        let access = engine.request(json!({"action":"root_access"})).unwrap();
+        assert_eq!(access[0]["status"], "available");
+        assert_eq!(
+            fs::read(moved.join("child/preserve.txt")).unwrap(),
+            b"disposable source"
+        );
+        assert_eq!(
+            engine.store.lock().unwrap().take_scope().unwrap(),
+            Some((renewed.id, renewed.path))
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn startup_rebinds_only_durably_anchored_device_changes() {
+        for scenario in ["valid", "wrong_anchor", "legacy", "transaction_failure"] {
+            let temp = tempfile::tempdir().unwrap();
+            let folder = temp.path().canonicalize().unwrap().join("chosen");
+            fs::create_dir_all(folder.join("child")).unwrap();
+            fs::write(folder.join("child/preserve.txt"), b"disposable source").unwrap();
+            let database = temp.path().join("db");
+            let (current, anchor) = safety::authorize_with_anchor(&folder, "folder").unwrap();
+            let mut anchor = anchor.unwrap();
+            if scenario == "wrong_anchor" {
+                anchor.volume_uuid[0] ^= 1;
+            }
+            let mut previous = current.clone();
+            previous.id = "before-remount".into();
+            previous.identity.device += 1;
+            {
+                let mut store = Store::open(&database).unwrap();
+                store
+                    .authorize_root_with_anchor(
+                        &previous,
+                        false,
+                        (scenario != "legacy").then_some(&anchor),
+                    )
+                    .unwrap();
+                store
+                    .keep(folder.join("preserved").to_str().unwrap(), true)
+                    .unwrap();
+                store
+                    .conn
+                    .execute(
+                        "UPDATE wallet SET collected=17,remainder=42,credited=1700000042",
+                        [],
+                    )
+                    .unwrap();
+                let candidate = indexed_fixture_source(&previous, "old");
+                store
+                    .conn
+                    .execute(
+                        "INSERT INTO candidates VALUES(?1,?2,?3,?4)",
+                        rusqlite::params![
+                            candidate.id,
+                            candidate.root_id,
+                            candidate.path.to_str(),
+                            serde_json::to_string(&candidate).unwrap()
+                        ],
+                    )
+                    .unwrap();
+                if scenario == "transaction_failure" {
+                    store.conn.execute_batch("CREATE TRIGGER fail_rebind BEFORE INSERT ON root_anchors BEGIN SELECT RAISE(ABORT,'disposable anchor failure'); END;").unwrap();
+                }
+            }
+            let engine = Engine::open(&database, None).unwrap();
+            let mut store = engine.store.lock().unwrap();
+            assert_eq!(store.wallet().unwrap().collected_coins, 17);
+            assert_eq!(store.kept().unwrap().len(), 1);
+            if scenario == "valid" {
+                assert!(store.root(&previous.id).is_err());
+                assert_eq!(
+                    store.root(&current.id).unwrap().identity.device,
+                    current.identity.device
+                );
+                assert!(store.candidate("old").is_err());
+                assert_eq!(
+                    store.take_scope().unwrap(),
+                    Some((current.id, current.path))
+                );
+            } else {
+                assert_eq!(
+                    store.root(&previous.id).unwrap().identity.device,
+                    previous.identity.device
+                );
+                assert!(store.root(&current.id).is_err());
+                assert!(store.candidate("old").is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn a_review_cannot_outlive_a_same_id_grant_policy_change() {
+        let (_temp, engine, roots) = foreground_fixture(1);
+        let previous = &roots[0];
+        let mut renewed = previous.clone();
+        renewed.kind = "home".into();
+        engine
+            .store
+            .lock()
+            .unwrap()
+            .reauthorize_root(&renewed, &previous.id, None)
+            .unwrap();
+        // Simulate a prepare request that captured the old grant before the
+        // change but reached review admission afterwards.
+        engine.reviews.lock().unwrap().insert(
+            "late-review".into(),
+            Review {
+                operation: "trash".into(),
+                items: vec![(previous.clone(), indexed_fixture_source(previous, "old"))],
+                created: now(),
+                cancel_generation: 0,
+                duplicate_keeper: None,
+                duplicate_created: None,
+            },
+        );
+        let error = engine
+            .request(json!({"action":"execute","token":"late-review","confirmed":true}))
+            .unwrap_err();
+        assert!(error.contains("Folder access"), "{error}");
+        assert!(engine.store.lock().unwrap().history().unwrap().is_empty());
+        assert_eq!(
+            fs::read(previous.path.join("child/preserve.txt")).unwrap(),
+            b"disposable source"
+        );
     }
 
     #[test]

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 pub const COIN_BYTES: u64 = 100_000_000;
 // Rebuild derived findings for category-specific everyday Mac recommendations.
-pub const RULE_VERSION: u32 = 10;
+pub const RULE_VERSION: u32 = 12;
 pub type Result<T> = std::result::Result<T, String>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -22,6 +22,31 @@ pub struct Root {
     pub path: PathBuf,
     pub kind: String,
     pub identity: Identity,
+}
+
+/// Durable macOS identity used only to renew a grant after device numbering
+/// changes. Live traversal and cleanup still use the current device identity.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RootAnchor {
+    pub volume_uuid: [u8; 16],
+    pub birth_seconds: i64,
+    pub birth_nanoseconds: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RootAccessStatus {
+    Available,
+    ReauthorizationRequired,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RootAccess {
+    pub root_id: String,
+    pub path: PathBuf,
+    pub status: RootAccessStatus,
+    pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/core/src/recommendations.rs
+++ b/core/src/recommendations.rs
@@ -6,20 +6,345 @@ use std::ffi::OsStr;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
-pub(crate) const HOME_LIBRARY_ROUTES: [&str; 3] = [
+pub(crate) const SWIFTPM_CACHE_ROUTE: &str = "Library/org.swift.swiftpm/cache";
+pub(crate) const HOME_LIBRARY_ROUTES: [&str; 5] = [
     "Library/Caches",
     "Library/Logs",
     "Library/Developer/Xcode/DerivedData",
+    "Library/Application Support",
+    SWIFTPM_CACHE_ROUTE,
 ];
 
+/// Only these generated leaves may be reviewed inside Application Support.
+/// In particular, browser profiles, offline storage, sessions, databases and
+/// all other siblings remain outside discovery and cleanup authorization.
+const SUPPORT_CACHE_APPS: &[(&str, &str)] = &[
+    ("Slack", "com.tinyspeck.slackmacgap"),
+    ("Claude", "com.anthropic.claudefordesktop"),
+    ("discord", "com.hnc.Discord"),
+    ("Code", "com.microsoft.VSCode"),
+    ("Cursor", "com.todesktop.230313mzl4w4u92"),
+];
+const SUPPORT_CACHE_LEAVES: &[&str] = &[
+    "Cache",
+    "Code Cache",
+    "GPUCache",
+    "DawnCache",
+    "DawnGraphiteCache",
+    "DawnWebGPUCache",
+];
+
+/// Generated application caches retain their review-and-Trash policy.
+const HOME_CACHE_ROUTES: &[(&str, &str)] = &[
+    (".cache/opencode", "OpenCode"),
+    (".cache/ghostty", "Ghostty"),
+    (".oh-my-zsh/cache", "Oh My Zsh"),
+];
+const HOME_LOG_ROUTES: &[&str] = &[".npm/_logs", ".config/gcloud/logs", ".azure/logs"];
+
+pub(crate) struct DeveloperCacheRoute {
+    pub path: &'static str,
+    pub title: &'static str,
+    pub owner: &'static str,
+}
+
+/// Exact generated stores under an explicit Home grant. Configuration,
+/// persistent credentials, installed toolchains and runtime versions are excluded.
+/// A matching location still needs full identity, activity, Git, link and
+/// manifest validation before either cleanup operation can be offered.
+pub(crate) const DEVELOPER_CACHE_ROUTES: &[DeveloperCacheRoute] = &[
+    DeveloperCacheRoute {
+        path: ".npm/_cacache",
+        title: "npm package cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".npm/_npx",
+        title: "npx temporary packages",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/node/corepack",
+        title: "Corepack package cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: "Library/Caches/node/corepack",
+        title: "Corepack package cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".bun/install/cache",
+        title: "Bun package cache",
+        owner: "bun",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/pip",
+        title: "pip download cache",
+        owner: "pip",
+    },
+    DeveloperCacheRoute {
+        path: "Library/Caches/pip",
+        title: "pip download cache",
+        owner: "pip",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/uv",
+        title: "uv package cache",
+        owner: "uv",
+    },
+    DeveloperCacheRoute {
+        path: "Library/Caches/uv",
+        title: "uv package cache",
+        owner: "uv",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/mise",
+        title: "mise download cache",
+        owner: "mise",
+    },
+    DeveloperCacheRoute {
+        path: "Library/Caches/mise",
+        title: "mise download cache",
+        owner: "mise",
+    },
+    DeveloperCacheRoute {
+        path: ".cargo/registry/cache",
+        title: "Cargo crate downloads",
+        owner: "cargo",
+    },
+    DeveloperCacheRoute {
+        path: ".cargo/registry/src",
+        title: "Cargo unpacked crates",
+        owner: "cargo",
+    },
+    DeveloperCacheRoute {
+        path: ".cargo/git/db",
+        title: "Cargo Git downloads",
+        owner: "cargo",
+    },
+    DeveloperCacheRoute {
+        path: ".cargo/git/checkouts",
+        title: "Cargo Git checkouts",
+        owner: "cargo",
+    },
+    DeveloperCacheRoute {
+        path: "Library/Caches/org.swift.swiftpm",
+        title: "SwiftPM package cache",
+        owner: "swiftpm",
+    },
+    DeveloperCacheRoute {
+        path: SWIFTPM_CACHE_ROUTE,
+        title: "SwiftPM package cache",
+        owner: "swiftpm",
+    },
+    DeveloperCacheRoute {
+        path: "Library/Caches/Homebrew/downloads",
+        title: "Homebrew downloads",
+        owner: "homebrew",
+    },
+    DeveloperCacheRoute {
+        path: ".aws/cli/cache",
+        title: "AWS CLI session cache",
+        owner: "aws",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/zig",
+        title: "Zig build cache",
+        owner: "zig",
+    },
+    DeveloperCacheRoute {
+        path: "Library/Caches/zig",
+        title: "Zig build cache",
+        owner: "zig",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/ruff",
+        title: "Ruff cache",
+        owner: "ruff",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/mypy",
+        title: "MyPy cache",
+        owner: "mypy",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/typescript",
+        title: "TypeScript cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/eslint",
+        title: "ESLint cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".cache/prettier",
+        title: "Prettier cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".expo/native-modules-cache",
+        title: "Expo native modules cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".expo/versions-cache",
+        title: "Expo versions cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".expo/schema-cache",
+        title: "Expo schema cache",
+        owner: "node",
+    },
+    DeveloperCacheRoute {
+        path: ".expo/template-cache",
+        title: "Expo templates cache",
+        owner: "node",
+    },
+];
+
+pub(crate) fn developer_cache_route(
+    root: &Root,
+    path: &Path,
+) -> Option<&'static DeveloperCacheRoute> {
+    if root.kind != "home" {
+        return None;
+    }
+    let relative = path.strip_prefix(&root.path).ok()?;
+    DEVELOPER_CACHE_ROUTES
+        .iter()
+        .find(|route| relative == Path::new(route.path))
+}
+
+pub(crate) fn developer_cache_route_allowed(root: &Root, path: &Path) -> bool {
+    root.kind == "home"
+        && path.strip_prefix(&root.path).is_ok_and(|relative| {
+            !relative.as_os_str().is_empty()
+                && DEVELOPER_CACHE_ROUTES.iter().any(|route| {
+                    relative.starts_with(route.path) || Path::new(route.path).starts_with(relative)
+                })
+        })
+}
+
+pub(crate) fn developer_cache_event_scope(root: &Root, path: &Path) -> Option<PathBuf> {
+    if root.kind != "home" {
+        return None;
+    }
+    let relative = path.strip_prefix(&root.path).ok()?;
+    DEVELOPER_CACHE_ROUTES.iter().find_map(|route| {
+        relative
+            .starts_with(route.path)
+            .then(|| root.path.join(route.path))
+    })
+}
+
+fn support_cache_unit(suffix: &Path) -> Option<(PathBuf, &'static str)> {
+    let mut components = suffix.components();
+    if let Some(app) = components.next().map(|part| part.as_os_str())
+        && let Some((_, owner)) = SUPPORT_CACHE_APPS
+            .iter()
+            .find(|(known, _)| app == OsStr::new(known))
+        && let Some(leaf) = components.next().map(|part| part.as_os_str())
+        && SUPPORT_CACHE_LEAVES
+            .iter()
+            .any(|known| leaf == OsStr::new(known))
+    {
+        return Some((Path::new(app).join(leaf), owner));
+    }
+    // The updater's download cache is separate from installed versions and
+    // registration state. No other Google application support is admitted.
+    let updater = Path::new("Google/GoogleUpdater/crx_cache");
+    suffix
+        .starts_with(updater)
+        .then(|| (updater.to_path_buf(), "com.google.GoogleUpdater"))
+}
+
+fn support_route_allowed(suffix: &Path) -> bool {
+    suffix.as_os_str().is_empty()
+        || SUPPORT_CACHE_APPS
+            .iter()
+            .any(|(app, _)| suffix == Path::new(app))
+        || matches!(suffix.to_str(), Some("Google" | "Google/GoogleUpdater"))
+        || support_cache_unit(suffix).is_some()
+}
+
+pub(crate) fn home_cache_candidate(
+    root: &Root,
+    path: &Path,
+    directory: bool,
+) -> Option<&'static str> {
+    if root.kind != "home" {
+        return None;
+    }
+    if directory && developer_cache_route(root, path).is_some() {
+        return Some("devcache");
+    }
+    let relative = path.strip_prefix(&root.path).ok()?;
+    if directory
+        && HOME_CACHE_ROUTES
+            .iter()
+            .any(|(route, _)| relative == Path::new(route))
+    {
+        Some("cache")
+    } else if !directory && home_log_scope(root, path) {
+        Some("log")
+    } else {
+        None
+    }
+}
+
+pub(crate) fn home_log_scope(root: &Root, path: &Path) -> bool {
+    root.kind == "home"
+        && path.strip_prefix(&root.path).is_ok_and(|relative| {
+            HOME_LOG_ROUTES
+                .iter()
+                .any(|route| relative.starts_with(route))
+        })
+}
+
+pub(crate) fn home_cache_event_scope(root: &Root, path: &Path) -> Option<PathBuf> {
+    if root.kind != "home" {
+        return None;
+    }
+    let relative = path.strip_prefix(&root.path).ok()?;
+    if let Some(scope) = developer_cache_event_scope(root, path) {
+        return Some(scope);
+    }
+    HOME_CACHE_ROUTES
+        .iter()
+        .find_map(|(route, _)| relative.starts_with(route).then(|| root.path.join(route)))
+        .or_else(|| home_log_scope(root, path).then(|| path.to_path_buf()))
+}
+
+pub(crate) fn cache_title(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy();
+    if let Some((app, _)) = path.parent().and_then(Path::file_name).and_then(|name| {
+        SUPPORT_CACHE_APPS
+            .iter()
+            .find(|(app, _)| name == OsStr::new(app))
+    }) && SUPPORT_CACHE_LEAVES.contains(&name.as_ref())
+    {
+        return Some(format!("{app} {name}"));
+    }
+    HOME_CACHE_ROUTES
+        .iter()
+        .find_map(|(route, title)| path.ends_with(route).then(|| format!("{title} cache")))
+        .or_else(|| {
+            path.ends_with("Google/GoogleUpdater/crx_cache")
+                .then(|| "GoogleUpdater download cache".into())
+        })
+}
+
 pub(crate) fn permanent_kind(kind: &str) -> bool {
-    matches!(kind, "cargo" | "node" | "venv" | "webcache")
+    matches!(kind, "cargo" | "node" | "venv" | "webcache" | "devcache")
 }
 
 pub(crate) fn review_project_kind(kind: &str) -> bool {
     matches!(
         kind,
-        "swiftpm" | "dotnet" | "gradle" | "dart" | "flutter" | "zig"
+        "swiftpm" | "dotnet" | "gradle" | "dart" | "flutter" | "zig" | "pythoncache"
     )
 }
 
@@ -37,11 +362,11 @@ pub(crate) fn checks_activity(kind: &str) -> bool {
 
 pub(crate) fn minimum_bytes(kind: &str) -> u64 {
     match kind {
-        "cache" | "archive" => 50_000_000,
-        "log" => 10_000_000,
-        "crashreport" => 1_000_000,
+        "cache" => 1_000_000,
+        "archive" => 50_000_000,
+        "log" | "crashreport" | "pythoncache" | "devcache" => 4_096,
         "installer" => 20_000_000,
-        "xcode" => 250_000_000,
+        "xcode" => 1_000_000,
         "largefile" => 500_000_000,
         "cargo" | "node" | "venv" | "webcache" | "download" => 100_000_000,
         kind if review_project_kind(kind) => 100_000_000,
@@ -49,17 +374,30 @@ pub(crate) fn minimum_bytes(kind: &str) -> u64 {
     }
 }
 
+pub(crate) fn minimum_size_label(kind: &str) -> String {
+    let bytes = minimum_bytes(kind);
+    if bytes >= 1_000_000 {
+        format!("{} MB", bytes / 1_000_000)
+    } else {
+        format!("{} KB", bytes / 1_024)
+    }
+}
+
 pub(crate) fn quiet_days(kind: &str) -> i64 {
     match kind {
+        "devcache" => 0,
         "cargo" | "node" | "venv" | "webcache" => 7,
+        "cache" => 1,
+        "log" | "crashreport" | "xcode" => 7,
         kind if review_project_kind(kind) => 7,
-        "installer" | "xcode" => 14,
+        "installer" => 14,
         "largefile" => 90,
         _ => 30,
     }
 }
 
-const KINDS: [&str; 18] = [
+const KINDS: [&str; 20] = [
+    "devcache",
     "cache",
     "log",
     "crashreport",
@@ -78,6 +416,7 @@ const KINDS: [&str; 18] = [
     "dart",
     "flutter",
     "zig",
+    "pythoncache",
 ];
 
 /// These SQL expressions are built once per query/index, from the same policy
@@ -100,7 +439,7 @@ pub(crate) fn priority_sql(column: &str) -> String {
     format!(
         "CASE json_extract({column},'$.kind') \
         WHEN 'log' THEN 0 WHEN 'crashreport' THEN 0 \
-        WHEN 'cache' THEN 1 WHEN 'webcache' THEN 1 WHEN 'dart' THEN 1 \
+        WHEN 'cache' THEN 1 WHEN 'devcache' THEN 1 WHEN 'webcache' THEN 1 WHEN 'dart' THEN 1 WHEN 'pythoncache' THEN 1 \
         WHEN 'cargo' THEN 2 WHEN 'xcode' THEN 2 WHEN 'zig' THEN 2 \
         WHEN 'dotnet' THEN 2 WHEN 'flutter' THEN 2 WHEN 'gradle' THEN 2 \
         WHEN 'swiftpm' THEN 3 WHEN 'node' THEN 3 WHEN 'venv' THEN 3 \
@@ -114,6 +453,7 @@ pub(crate) enum LibraryArea {
     Caches,
     Logs,
     Xcode,
+    ApplicationSupport,
 }
 
 /// Only an explicit Home grant opts into these routes. A project containing a
@@ -123,10 +463,12 @@ pub(crate) fn library_area<'a>(root: &Root, path: &'a Path) -> Option<(LibraryAr
         return None;
     }
     let relative = path.strip_prefix(&root.path).ok()?;
-    for (route, area) in HOME_LIBRARY_ROUTES.into_iter().zip([
+    // The fifth start is an exact candidate, not an open-ended Library area.
+    for (route, area) in HOME_LIBRARY_ROUTES.into_iter().take(4).zip([
         LibraryArea::Caches,
         LibraryArea::Logs,
         LibraryArea::Xcode,
+        LibraryArea::ApplicationSupport,
     ]) {
         if let Ok(suffix) = relative.strip_prefix(route) {
             return Some((area, suffix));
@@ -140,14 +482,25 @@ pub(crate) fn library_corridor(root: &Root, path: &Path) -> bool {
         && path.strip_prefix(&root.path).is_ok_and(|relative| {
             matches!(
                 relative.to_str(),
-                Some("Library" | "Library/Developer" | "Library/Developer/Xcode")
+                Some(
+                    "Library"
+                        | "Library/Developer"
+                        | "Library/Developer/Xcode"
+                        | "Library/org.swift.swiftpm"
+                )
             )
         })
 }
 
-/// Package caches need their manager's own preview/prune protocol. Do not
-/// reinterpret a familiar manager's opaque store as an ordinary app cache.
+/// Unrecognized manager stores never fall through to the app-cache adapter.
+/// Only the exact developer-cache table can admit a generated manager route.
 pub(crate) fn managed_cache(name: &OsStr) -> bool {
+    // The Library name filter has no Root, but it is used only after the
+    // caller enters an authorized Library/Caches lane. Admit table corridors;
+    // library_route_allowed still rejects every unsupported child below them.
+    if developer_library_cache_name(name) {
+        return false;
+    }
     let Some(name) = name.to_str() else {
         return true;
     };
@@ -168,18 +521,48 @@ pub(crate) fn managed_cache(name: &OsStr) -> bool {
     .any(|known| name.eq_ignore_ascii_case(known))
 }
 
+fn developer_library_cache_name(name: &OsStr) -> bool {
+    DEVELOPER_CACHE_ROUTES.iter().any(|route| {
+        Path::new(route.path)
+            .strip_prefix("Library/Caches")
+            .is_ok_and(|suffix| {
+                suffix
+                    .components()
+                    .next()
+                    .is_some_and(|part| part.as_os_str() == name)
+            })
+    })
+}
+
 pub(crate) fn library_route_allowed(root: &Root, path: &Path) -> bool {
     if library_corridor(root, path) {
         return true;
     }
+    if root.kind == "home"
+        && path
+            .strip_prefix(&root.path)
+            .is_ok_and(|relative| relative.starts_with("Library"))
+        && developer_cache_route_allowed(root, path)
+    {
+        return true;
+    }
     library_area(root, path).is_some_and(|(area, suffix)| {
+        if area == LibraryArea::ApplicationSupport {
+            return support_route_allowed(suffix);
+        }
         if area != LibraryArea::Caches {
+            return true;
+        }
+        if developer_cache_route_allowed(root, path) {
             return true;
         }
         let mut components = suffix.components();
         let Some(first) = components.next().map(|component| component.as_os_str()) else {
             return true;
         };
+        if developer_library_cache_name(first) {
+            return false;
+        }
         if managed_cache(first) {
             return false;
         }
@@ -218,11 +601,18 @@ fn path_ends_with_ascii_case(path: &Path, suffix: &[&str]) -> bool {
     })
 }
 
-/// Return the bundle identifier for a recognized browser profile cache. The
-/// caller must have already validated this as a Home Library/Caches location;
-/// the suffix match here only prevents an unrelated cache from being treated
-/// as browser-owned activity.
+/// Return the owner of an exact browser profile or known Application Support
+/// cache leaf. The caller must already have validated its Home cache location;
+/// lexical recognition never authorizes an arbitrary path or sibling data.
 pub(crate) fn browser_cache_owner(location: &Path) -> Option<&'static str> {
+    for ancestor in location.ancestors() {
+        if path_ends_with_ascii_case(ancestor, &["Library", "Application Support"]) {
+            let suffix = location.strip_prefix(ancestor).ok()?;
+            return support_cache_unit(suffix)
+                .filter(|(unit, _)| suffix == unit)
+                .map(|(_, owner)| owner);
+        }
+    }
     let profile = location.file_name()?;
     if !browser_component_allowed(profile) {
         return None;
@@ -238,6 +628,12 @@ pub(crate) fn browser_cache_owner(location: &Path) -> Option<&'static str> {
 }
 
 pub(crate) fn library_candidate(root: &Root, path: &Path, directory: bool) -> Option<&'static str> {
+    if developer_cache_route(root, path).is_some() {
+        return directory.then_some("devcache");
+    }
+    if developer_cache_route_allowed(root, path) {
+        return None;
+    }
     let (area, suffix) = library_area(root, path)?;
     if suffix.as_os_str().is_empty() || !library_route_allowed(root, path) {
         return None;
@@ -288,6 +684,9 @@ pub(crate) fn library_candidate(root: &Root, path: &Path, directory: bool) -> Op
             "log"
         }),
         LibraryArea::Xcode if directory && suffix.components().count() == 1 => Some("xcode"),
+        LibraryArea::ApplicationSupport if directory => support_cache_unit(suffix)
+            .filter(|(unit, _)| suffix == unit)
+            .map(|_| "cache"),
         _ => None,
     }
 }
@@ -295,6 +694,9 @@ pub(crate) fn library_candidate(root: &Root, path: &Path, directory: bool) -> Op
 /// Changes inside a cache/build unit invalidate that exact unit. Logs stay
 /// file-scoped, so a logging app cannot continually rescan all user logs.
 pub(crate) fn library_event_scope(root: &Root, path: &Path) -> Option<PathBuf> {
+    if let Some(scope) = developer_cache_event_scope(root, path) {
+        return Some(scope);
+    }
     let (area, suffix) = library_area(root, path)?;
     if !library_route_allowed(root, path) {
         return None;
@@ -302,10 +704,23 @@ pub(crate) fn library_event_scope(root: &Root, path: &Path) -> Option<PathBuf> {
     if area == LibraryArea::Logs || suffix.as_os_str().is_empty() {
         return Some(path.to_path_buf());
     }
+    if developer_cache_route_allowed(root, path) {
+        return Some(path.to_path_buf());
+    }
+    if area == LibraryArea::ApplicationSupport {
+        return Some(
+            root.path.join(HOME_LIBRARY_ROUTES[3]).join(
+                support_cache_unit(suffix)
+                    .map(|(unit, _)| unit)
+                    .unwrap_or_else(|| suffix.to_path_buf()),
+            ),
+        );
+    }
     let route = match area {
         LibraryArea::Caches => HOME_LIBRARY_ROUTES[0],
         LibraryArea::Xcode => HOME_LIBRARY_ROUTES[2],
         LibraryArea::Logs => unreachable!(),
+        LibraryArea::ApplicationSupport => unreachable!(),
     };
     if area == LibraryArea::Caches {
         let mut components = suffix.components();
@@ -450,7 +865,7 @@ mod tests {
             "Library/Developer/CoreSimulator",
             "Projects/Library/Caches/app",
             "Library/Caches-old/app",
-            "Library/Caches/uv/item",
+            "Library/Caches/pnpm/item",
             "Library/Caches/Homebrew/item",
         ] {
             assert!(
@@ -463,6 +878,186 @@ mod tests {
             &root,
             &root.path.join("Library/Caches/app")
         ));
+    }
+
+    #[test]
+    fn support_and_hidden_cache_routes_are_exact_generated_leaves() {
+        let mut root = home();
+        for relative in [
+            "Library/Application Support/Slack/Cache",
+            "Library/Application Support/Slack/Code Cache",
+            "Library/Application Support/Claude/GPUCache",
+            "Library/Application Support/Code/DawnGraphiteCache",
+            "Library/Application Support/Google/GoogleUpdater/crx_cache",
+        ] {
+            let path = root.path.join(relative);
+            assert!(library_route_allowed(&root, &path));
+            assert_eq!(library_candidate(&root, &path, true), Some("cache"));
+            assert_eq!(library_candidate(&root, &path, false), None);
+            assert_eq!(
+                library_event_scope(&root, &path.join("nested/payload")),
+                Some(path)
+            );
+        }
+        for relative in [
+            "Library/Application Support/Slack/Local Storage",
+            "Library/Application Support/Slack/Service Worker/CacheStorage",
+            "Library/Application Support/Slack/Cache-backup",
+            "Library/Application Support/Claude/claude-code",
+            "Library/Application Support/Google/Chrome/Default/Cache",
+            "Library/Application Support/Google/GoogleUpdater/Current",
+            "Library/Application Support/Unknown/Cache",
+        ] {
+            assert!(
+                !library_route_allowed(&root, &root.path.join(relative)),
+                "{relative}"
+            );
+        }
+        for (relative, kind) in [
+            (".cache/zig", "devcache"),
+            (".expo/versions-cache", "devcache"),
+            (".oh-my-zsh/cache", "cache"),
+        ] {
+            let path = root.path.join(relative);
+            assert_eq!(home_cache_candidate(&root, &path, true), Some(kind));
+            assert_eq!(
+                home_cache_candidate(&root, &path.join("nested"), true),
+                None
+            );
+            assert_eq!(
+                home_cache_event_scope(&root, &path.join("payload")),
+                Some(path)
+            );
+        }
+        assert_eq!(
+            home_cache_candidate(&root, &root.path.join(".npm/_logs/old.log"), false),
+            Some("log")
+        );
+        for relative in [
+            ".cache",
+            ".cache/unknown",
+            ".npm/_update-notifier-last-checked",
+            ".cargo/git",
+            ".aws/credentials",
+        ] {
+            assert_eq!(
+                home_cache_candidate(&root, &root.path.join(relative), true),
+                None
+            );
+        }
+        assert_eq!(
+            browser_cache_owner(&root.path.join("Library/Application Support/Slack/Cache")),
+            Some("com.tinyspeck.slackmacgap")
+        );
+        assert_eq!(
+            browser_cache_owner(
+                &root
+                    .path
+                    .join("Library/Application Support/Slack/Local Storage")
+            ),
+            None
+        );
+        root.kind = "folder".into();
+        assert!(!library_route_allowed(
+            &root,
+            &root.path.join("Library/Application Support/Slack/Cache")
+        ));
+        assert_eq!(
+            home_cache_candidate(&root, &root.path.join(".cache/zig"), true),
+            None
+        );
+    }
+
+    #[test]
+    fn generated_data_has_useful_floors_without_changing_personal_or_permanent_policy() {
+        assert_eq!(
+            (minimum_bytes("devcache"), quiet_days("devcache")),
+            (4096, 0)
+        );
+        assert!(
+            permanent_kind("devcache") && checks_git("devcache") && checks_activity("devcache")
+        );
+        assert_eq!(
+            (minimum_bytes("cache"), quiet_days("cache")),
+            (1_000_000, 1)
+        );
+        assert_eq!((minimum_bytes("log"), quiet_days("log")), (4_096, 7));
+        assert_eq!(
+            (minimum_bytes("xcode"), quiet_days("xcode")),
+            (1_000_000, 7)
+        );
+        assert_eq!(minimum_size_label("log"), "4 KB");
+        assert_eq!(minimum_size_label("cache"), "1 MB");
+        assert_eq!(
+            (minimum_bytes("largefile"), quiet_days("largefile")),
+            (500_000_000, 90)
+        );
+        assert_eq!(
+            (minimum_bytes("cargo"), quiet_days("cargo")),
+            (100_000_000, 7)
+        );
+        assert!(!permanent_kind("pythoncache"));
+        assert!(checks_git("pythoncache") && checks_activity("pythoncache"));
+    }
+
+    #[test]
+    fn devcache_routes_require_exact_home_leaves_and_never_cover_adjacent_state() {
+        let root = home();
+        for route in DEVELOPER_CACHE_ROUTES {
+            let path = root.path.join(route.path);
+            assert_eq!(
+                developer_cache_route(&root, &path).unwrap().path,
+                route.path
+            );
+            assert_eq!(home_cache_candidate(&root, &path, true), Some("devcache"));
+            assert_eq!(home_cache_candidate(&root, &path, false), None);
+            assert!(developer_cache_route(&root, &path.join("child")).is_none());
+            assert_eq!(
+                developer_cache_event_scope(&root, &path.join("child/nested")),
+                Some(path.clone())
+            );
+            if route.path.starts_with("Library/") {
+                assert!(library_route_allowed(&root, &path));
+                assert_eq!(library_candidate(&root, &path, true), Some("devcache"));
+            }
+            for kind in ["projects", "folder", "downloads"] {
+                let mut other = root.clone();
+                other.kind = kind.into();
+                assert!(developer_cache_route(&other, &path).is_none());
+                assert!(home_cache_candidate(&other, &path, true).is_none());
+            }
+        }
+        for path in [
+            ".cargo",
+            ".cargo/bin",
+            ".cargo/registry",
+            ".npm",
+            ".bun/install",
+            ".rustup/toolchains",
+            ".local/share/mise/installs",
+            ".aws/credentials",
+            ".aws/config",
+            ".expo/state.json",
+            "Library/Caches/Homebrew",
+            "Library/Caches/Homebrew/locks",
+            "Library/Caches/node/other",
+            "Library/org.swift.swiftpm/configuration",
+        ] {
+            assert!(
+                developer_cache_route(&root, &root.path.join(path)).is_none(),
+                "{path}"
+            );
+            assert!(
+                home_cache_candidate(&root, &root.path.join(path), true).is_none(),
+                "{path}"
+            );
+            if path.starts_with("Library/") && !matches!(path, "Library/Caches/Homebrew") {
+                assert!(
+                    !library_route_allowed(&root, &root.path.join(path)),
+                    "{path}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/core/src/refresh.rs
+++ b/core/src/refresh.rs
@@ -223,8 +223,13 @@ pub(crate) fn event_scope_with_kind(
     if safety::excluded_home_media(root, path) {
         return Ok(None);
     }
+    if let Some(scope) = recommendations::home_cache_event_scope(root, path) {
+        return Ok((kind != EventKind::Directory || recursive)
+            .then_some(scope)
+            .filter(|scope| safety::check_scope_policy(root, scope).is_ok()));
+    }
     if recommendations::library_corridor(root, path) {
-        // Structural events for these corridors expand only into the three
+        // Structural events for these corridors expand only into the fixed
         // fixed cleanup routes, never an unrestricted Library walk.
         return Ok((kind != EventKind::Directory || recursive).then(|| path.to_path_buf()));
     }
@@ -396,6 +401,9 @@ pub(crate) fn resolve_scope(root: &Root, path: &Path, indexed: Option<PathBuf>) 
     if let Some(scope) = recommendations::library_event_scope(root, path) {
         return Ok(scope);
     }
+    if let Some(scope) = recommendations::home_cache_event_scope(root, path) {
+        return Ok(scope);
+    }
     normalize_scope(root, indexed.as_deref().unwrap_or(path))
 }
 
@@ -411,6 +419,9 @@ pub(crate) fn normalize_scope(root: &Root, path: &Path) -> Result<PathBuf> {
         return Ok(path.to_path_buf());
     }
     if let Some(scope) = recommendations::library_event_scope(root, path) {
+        return Ok(scope);
+    }
+    if let Some(scope) = recommendations::home_cache_event_scope(root, path) {
         return Ok(scope);
     }
     let selected = path
@@ -776,6 +787,20 @@ mod tests {
             ),
             ("Library/Logs/app/old.log", "Library/Logs/app/old.log"),
             (
+                "Library/Application Support/Slack/Cache/nested/item",
+                "Library/Application Support/Slack/Cache",
+            ),
+            (
+                "Library/Application Support/Slack/Code Cache/.git/index",
+                "Library/Application Support/Slack/Code Cache",
+            ),
+            (".cache/zig/nested/item", ".cache/zig"),
+            (".npm/_logs/old.log", ".npm/_logs/old.log"),
+            (
+                "Documents/project/__pycache__/module.cpython-314.pyc",
+                "Documents/project/__pycache__",
+            ),
+            (
                 "Library/Logs/DiagnosticReports/report.ips",
                 "Library/Logs/DiagnosticReports/report.ips",
             ),
@@ -789,7 +814,8 @@ mod tests {
         }
         for relative in [
             "Library/Application Support/app/state",
-            "Library/Caches/uv/item",
+            "Library/Application Support/Slack/Local Storage/state",
+            "Library/Caches/pnpm/item",
             "Library/Caches/Homebrew/item",
             "Library/Caches/.git/index",
             "Library/Logs/Dropbox/report.log",
@@ -812,6 +838,42 @@ mod tests {
             event_scope_with_kind(&root, &library, EventKind::Directory, true).unwrap(),
             Some(library)
         );
+    }
+
+    #[test]
+    fn devcache_events_keep_exact_units_and_preserve_global_cargo_config_invalidation() {
+        let mut root = root();
+        root.kind = "home".into();
+        for route in recommendations::DEVELOPER_CACHE_ROUTES {
+            let unit = root.path.join(route.path);
+            for suffix in ["payload", "nested/item", ".git/config"] {
+                let path = unit.join(suffix);
+                assert_eq!(
+                    event_scope_with_kind(&root, &path, EventKind::File, false).unwrap(),
+                    Some(unit.clone())
+                );
+                if suffix != ".git/config" {
+                    assert_eq!(normalize_scope(&root, &path).unwrap(), unit);
+                }
+            }
+        }
+        for suffix in [".cargo/config", ".cargo/config.toml"] {
+            assert_eq!(
+                event_scope_with_kind(&root, &root.path.join(suffix), EventKind::File, false)
+                    .unwrap(),
+                Some(root.path.clone())
+            );
+        }
+        for suffix in [
+            "Library/Caches/Homebrew/locks/keep.lock",
+            "Library/org.swift.swiftpm/configuration/settings.json",
+        ] {
+            assert_eq!(
+                event_scope_with_kind(&root, &root.path.join(suffix), EventKind::File, false)
+                    .unwrap(),
+                None
+            );
+        }
     }
 
     #[test]

--- a/core/src/safety.rs
+++ b/core/src/safety.rs
@@ -3,7 +3,7 @@
 //! Paths are display names. Once a traversal starts, directory descriptors anchor
 //! its reads; `openat(O_NOFOLLOW)` and `fstatat(AT_SYMLINK_NOFOLLOW)` never follow a
 //! replaced link. This is a metadata fingerprint, deliberately not a content hash.
-use crate::model::{Identity, Result, Root};
+use crate::model::{Identity, Result, Root, RootAccess, RootAccessStatus, RootAnchor};
 use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, CString, OsStr};
 use std::fs::File;
@@ -20,6 +20,8 @@ const MAX_MANIFEST: u64 = 4 * 1024 * 1024;
 const SCOPE_OBSERVATION_ATTEMPTS: usize = 3;
 pub(crate) const SCOPE_CONTENTS_CHANGED: &str =
     "Files changed during refresh; this scope will be checked again.";
+const ROOT_IDENTITY_CHANGED: &str =
+    "Folder access needs to be renewed. Choose this folder again in Settings.";
 
 /// Only callers that have recognized an owned developer artifact may opt in to
 /// generated application bundles and non-followed symbolic-link leaves. Folder
@@ -338,7 +340,7 @@ fn scope_metadata_impl(
     scope_checkpoint(cancel, checkpoint)?;
     let meta = scope_parent_metadata(fd.as_raw_fd(), root.identity.device, cancel)?;
     if !same_object(&root.identity, &meta.identity) {
-        return Err("The authorized folder has been replaced; choose it again".into());
+        return Err(ROOT_IDENTITY_CHANGED.into());
     }
     check_scope_ancestor(ancestor, 0, &meta)?;
     scope_checkpoint(cancel, checkpoint)?;
@@ -903,6 +905,10 @@ pub(crate) fn validate_ancestors(path: &Path) -> Result<()> {
 }
 
 pub fn authorize(path: &Path, kind: &str) -> Result<Root> {
+    authorize_with_anchor(path, kind).map(|(root, _)| root)
+}
+
+pub(crate) fn authorize_with_anchor(path: &Path, kind: &str) -> Result<(Root, Option<RootAnchor>)> {
     let _local_io = LocalOnlyIo::new()?;
     if !matches!(kind, "projects" | "downloads" | "folder" | "home") {
         return Err("Choose a projects, downloads, folder, or home location kind".into());
@@ -924,12 +930,96 @@ pub fn authorize(path: &Path, kind: &str) -> Result<Root> {
     hash.update(canonical.as_os_str().as_bytes());
     hash.update(&meta.identity.device.to_le_bytes());
     hash.update(&meta.identity.inode.to_le_bytes());
-    Ok(Root {
-        id: hash.finalize().to_hex()[..24].to_string(),
-        path: canonical,
-        kind: kind.into(),
-        identity: meta.identity,
-    })
+    // Capture before the last pathname identity check. The descriptor remains
+    // pinned, and no anchor may describe a different directory from the grant.
+    let anchor = root_anchor(fd.as_raw_fd())?;
+    if !same_object(&meta.identity, &identity(&canonical)?) {
+        return Err("The selected folder changed while confirming access".into());
+    }
+    Ok((
+        Root {
+            id: hash.finalize().to_hex()[..24].to_string(),
+            path: canonical,
+            kind: kind.into(),
+            identity: meta.identity,
+        },
+        anchor,
+    ))
+}
+
+fn root_anchor(fd: RawFd) -> Result<Option<RootAnchor>> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut attributes: libc::attrlist = unsafe { std::mem::zeroed() };
+        attributes.bitmapcount = 5;
+        // ATTR_VOL_INFO | ATTR_VOL_UUID, from sys/attr.h. The result is a
+        // packed u32 byte count followed by the volume's 16 UUID bytes.
+        attributes.volattr = 0x8004_0000;
+        let mut bytes = [0u8; 20];
+        let status = unsafe {
+            libc::fgetattrlist(
+                fd,
+                (&mut attributes as *mut libc::attrlist).cast(),
+                bytes.as_mut_ptr().cast(),
+                bytes.len(),
+                0,
+            )
+        };
+        if status != 0 || u32::from_ne_bytes(bytes[..4].try_into().unwrap()) != 20 {
+            // Some local filesystems do not expose a persistent UUID. They
+            // retain strict session identities and can be renewed explicitly.
+            return Ok(None);
+        }
+        let volume_uuid: [u8; 16] = bytes[4..].try_into().unwrap();
+        let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+        if unsafe { libc::fstat(fd, &mut stat) } != 0 {
+            return Err(os_error("Cannot confirm the selected folder's identity"));
+        }
+        if volume_uuid == [0; 16] || stat.st_birthtime <= 0 {
+            return Ok(None);
+        }
+        Ok(Some(RootAnchor {
+            volume_uuid,
+            birth_seconds: stat.st_birthtime,
+            birth_nanoseconds: stat.st_birthtime_nsec,
+        }))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = fd;
+        Ok(None)
+    }
+}
+
+/// Called only before engine workers/reviews exist. A volume-number change may
+/// renew discovery, never old findings: UUID, inode, birthtime and full mode all
+/// have to match, and the replacement grant is freshly authorized as usual.
+pub(crate) fn rebind_root(root: &Root, anchor: &RootAnchor) -> Result<Option<Root>> {
+    let (current, current_anchor) = authorize_with_anchor(&root.path, &root.kind)?;
+    if current.identity.device == root.identity.device
+        || current.identity.inode != root.identity.inode
+        || current.identity.mode != root.identity.mode
+        || current_anchor.as_ref() != Some(anchor)
+    {
+        return Ok(None);
+    }
+    Ok(Some(current))
+}
+
+pub(crate) fn root_access(root: &Root) -> RootAccess {
+    let (status, message) = match validate_root(root) {
+        Ok(()) => (RootAccessStatus::Available, None),
+        Err(message) if message == ROOT_IDENTITY_CHANGED => {
+            (RootAccessStatus::ReauthorizationRequired, Some(message))
+        }
+        Err(message) => (RootAccessStatus::Unavailable, Some(message)),
+    };
+    RootAccess {
+        root_id: root.id.clone(),
+        path: root.path.clone(),
+        status,
+        message,
+    }
 }
 
 pub fn validate_root(root: &Root) -> Result<()> {
@@ -937,7 +1027,7 @@ pub fn validate_root(root: &Root) -> Result<()> {
     let fd = open_directory(&root.path)?;
     check_local(fd.as_raw_fd())?;
     if !same_object(&root.identity, &stat_fd(fd.as_raw_fd())?.identity) {
-        return Err("The authorized folder has been replaced; choose it again".into());
+        return Err(ROOT_IDENTITY_CHANGED.into());
     }
     validate_ancestors(&root.path)
 }
@@ -4860,11 +4950,13 @@ pub(crate) mod tests {
     #[test]
     fn library_names_exclude_protected_and_managed_entries_before_metadata() {
         let (_temp, base) = fixture();
-        let excluded = [".git", "Library", "Dropbox", "Homebrew", "uv", "pip"];
+        let excluded = [".git", "Library", "Dropbox", "pnpm", "yarn", "cocoapods"];
         for name in excluded {
             std::fs::create_dir(base.join(name)).unwrap();
         }
-        std::fs::create_dir(base.join("com.example.browser")).unwrap();
+        for name in ["Homebrew", "uv", "pip", "com.example.browser"] {
+            std::fs::create_dir(base.join(name)).unwrap();
+        }
         std::fs::write(base.join("ordinary.log"), b"fixture").unwrap();
         symlink("ordinary.log", base.join("linked.log")).unwrap();
         for unknown_types in [false, true] {
@@ -4891,14 +4983,20 @@ pub(crate) mod tests {
             selected.sort();
             assert_eq!(
                 selected,
-                [base.join("com.example.browser"), base.join("ordinary.log")]
+                [
+                    base.join("Homebrew"),
+                    base.join("com.example.browser"),
+                    base.join("ordinary.log"),
+                    base.join("pip"),
+                    base.join("uv"),
+                ]
             );
             assert_eq!(skipped, excluded.len() as u64 + 1);
             // Unknown types need a no-follow stat for the ordinary directory
-            // and link too; protected names never need one in either mode.
+            // and admitted cache directories too; protected names never need one.
             assert_eq!(
                 CHILD_METADATA_CALLS.with(std::cell::Cell::get) - before,
-                if unknown_types { 3 } else { 1 }
+                if unknown_types { 6 } else { 1 }
             );
         }
     }
@@ -5193,6 +5291,58 @@ pub(crate) mod tests {
         std::fs::rename(&chosen, base.join("old")).unwrap();
         std::fs::create_dir(&chosen).unwrap();
         assert!(validate_root(&root).is_err());
+    }
+
+    #[test]
+    fn root_contents_churn_does_not_require_reauthorization() {
+        let (_temp, base) = fixture();
+        let root = authorize(&base, "projects").unwrap();
+        std::fs::write(base.join("new-work"), b"preserve").unwrap();
+        validate_root(&root).unwrap();
+        assert!(matches!(
+            root_access(&root).status,
+            RootAccessStatus::Available
+        ));
+        let mut stale = root.clone();
+        stale.identity.device = stale.identity.device.wrapping_add(1);
+        let access = root_access(&stale);
+        assert!(matches!(
+            access.status,
+            RootAccessStatus::ReauthorizationRequired
+        ));
+        assert_eq!(access.root_id, root.id);
+        assert_eq!(access.path, base);
+        assert!(access.message.unwrap().contains("Settings"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn remounted_root_requires_uuid_birth_inode_and_mode() {
+        let (_temp, base) = fixture();
+        let (current, anchor) = authorize_with_anchor(&base, "projects").unwrap();
+        let anchor = anchor.expect("The local macOS test volume exposes a durable identity");
+        let mut remounted = current.clone();
+        remounted.identity.device = remounted.identity.device.wrapping_add(1);
+        assert!(validate_root(&remounted).is_err());
+        let renewed = rebind_root(&remounted, &anchor).unwrap().unwrap();
+        assert_eq!(renewed.id, current.id);
+        assert_eq!(renewed.identity.device, current.identity.device);
+        assert!(rebind_root(&current, &anchor).unwrap().is_none());
+        for changed in ["uuid", "birth", "inode", "mode"] {
+            let mut wrong_root = remounted.clone();
+            let mut wrong_anchor = anchor.clone();
+            match changed {
+                "uuid" => wrong_anchor.volume_uuid[0] ^= 1,
+                "birth" => wrong_anchor.birth_nanoseconds ^= 1,
+                "inode" => wrong_root.identity.inode ^= 1,
+                "mode" => wrong_root.identity.mode ^= 1,
+                _ => unreachable!(),
+            }
+            assert!(
+                rebind_root(&wrong_root, &wrong_anchor).unwrap().is_none(),
+                "{changed}"
+            );
+        }
     }
 
     #[test]

--- a/core/src/scanner.rs
+++ b/core/src/scanner.rs
@@ -28,7 +28,9 @@ const BATCH_INTERVAL: Duration = Duration::from_millis(100);
 const MAX_BATCH: usize = 64;
 const MAX_SHALLOW_FRONTIER: usize = 32;
 const MAX_DEFERRED_ARTIFACTS: usize = 256;
-const MAX_SCAN_LANES: usize = 4;
+const MAX_SCAN_LANES: usize = 6;
+const SUPPORT_DISCOVERY_DESCRIPTORS: usize = 4;
+const SWIFTPM_DISCOVERY_DESCRIPTORS: usize = 1;
 const MAX_MEASUREMENT_JOB_BYTES: usize = 1024 * 1024;
 const MEASUREMENT_QUANTUM_ENTRIES: usize = 256;
 const MEASUREMENT_QUANTUM: Duration = Duration::from_millis(5);
@@ -37,8 +39,7 @@ const MEASUREMENT_QUANTUM: Duration = Duration::from_millis(5);
 // budget plus non-traversal headroom before admitting filesystem work; the
 // native host's descriptor limits are never changed by discovery.
 pub(crate) const MAX_SCHEDULED_DIRECTORY_FDS: usize = MAX_SHALLOW_FRONTIER + 6 * safety::MAX_DEPTH;
-const MAX_ACTIVE_MEASUREMENTS: usize =
-    (MAX_SCHEDULED_DIRECTORY_FDS - MAX_SHALLOW_FRONTIER) / safety::MAX_DEPTH - MAX_SCAN_LANES;
+const MAX_ACTIVE_MEASUREMENTS: usize = 2;
 const DAY_NS: i64 = 86_400_000_000_000;
 const DEVELOPER_QUIET_DAYS: i64 = 7;
 #[cfg(test)]
@@ -1319,8 +1320,8 @@ fn suggestion_reason(found: &Evidence, measured: &Measurement, now_ns: i64) -> O
     let minimum = recommendations::minimum_bytes(found.kind);
     if measured.allocated_bytes < minimum {
         return Some(format!(
-            "Less than {} MB is allocated locally; it does not meet this category's size threshold",
-            minimum / 1_000_000
+            "Less than {} is allocated locally; it does not meet this category's size threshold",
+            recommendations::minimum_size_label(found.kind)
         ));
     }
     let latest = measured.latest_modified_ns.max(found.latest_modified_ns);
@@ -1338,12 +1339,16 @@ fn everyday_evidence(path: &Path, meta: &EntryMeta, kind: &'static str) -> Optio
         return None;
     }
     let (explanation, consequence) = match kind {
+        "devcache" => (
+            "Generated developer cache data in an exact recognized location under your authorized Home folder. The complete contents and current tool activity are checked before cleanup; adjacent configuration, installed runtimes and toolchains are excluded.",
+            "Clearing this cache removes the reviewed files. The owning tool may need to download packages, rebuild cached data, or sign in again. Close its running tools first. Permanent cleanup cannot be undone; Move to Trash remains available.",
+        ),
         "cache" => (
-            "An old cache in your authorized user Library/Caches location. Apps may regenerate or download this data again; it is not personal application-support data.",
+            "Generated cache data in a recognized location under your authorized Home folder. Apps may regenerate or download this data again; personal application data and offline browser storage are excluded.",
             "Close the owning app before moving this cache to Trash. Ownership cannot always be identified; an app can keep writing to files in Trash, and changes there can prevent automatic restore. The app may need network access or start more slowly. Keep offline data you still need. Trash does not free space or earn chips.",
         ),
         "log" => (
-            "An old, sizeable log file in your authorized user Library/Logs location. Logs can help diagnose a problem; age does not establish that they are no longer needed.",
+            "An older log file in a recognized app or developer-tool log location under your authorized Home folder. Logs can help diagnose a problem; age does not establish that they are no longer needed.",
             "Review this log before moving it to Trash. Keep it if you are troubleshooting or need a diagnostic record. Trash does not free space or earn chips.",
         ),
         "crashreport" => (
@@ -1374,10 +1379,14 @@ fn everyday_evidence(path: &Path, meta: &EntryMeta, kind: &'static str) -> Optio
     };
     let name = path.file_name()?.to_string_lossy();
     let title = match kind {
+        "devcache" => recommendations::DEVELOPER_CACHE_ROUTES
+            .iter()
+            .find(|route| path.ends_with(route.path))
+            .map(|route| route.title.to_owned())?,
         "cache" => match recommendations::browser_cache_owner(path) {
             Some("com.google.Chrome") => format!("Chrome {name} cache"),
             Some("org.chromium.Chromium") => format!("Chromium {name} cache"),
-            _ => format!("{name} cache"),
+            _ => recommendations::cache_title(path).unwrap_or_else(|| format!("{name} cache")),
         },
         "xcode" => format!("{name} Xcode data"),
         _ => name.into_owned(),
@@ -1393,6 +1402,115 @@ fn everyday_evidence(path: &Path, meta: &EntryMeta, kind: &'static str) -> Optio
         quiet_days: recommendations::quiet_days(kind),
         activity_root: recommendations::checks_activity(kind).then(|| path.to_path_buf()),
     })
+}
+
+/// A `__pycache__` name alone is not enough: every entry must be a bounded,
+/// independently owned CPython bytecode file with a corresponding regular
+/// source file beside the cache. This never treats source-less bytecode,
+/// arbitrary files, nested directories or links as disposable output.
+fn python_cache_evidence(
+    root: &Root,
+    path: &Path,
+    cancel: &AtomicBool,
+) -> Result<Option<Evidence>> {
+    const MAX_FILES: usize = 256;
+    const MAX_FILE_BYTES: u64 = 1_048_576;
+    const MAX_TOTAL_BYTES: u64 = 8_388_608;
+    let parent = path
+        .parent()
+        .ok_or("Python cache has no source directory")?;
+    let before = safety::scope_metadata(root, path, cancel)?
+        .ok_or("Python cache disappeared before inspection")?;
+    let mut directory = Directory::open(path)?;
+    let mut captures = Vec::new();
+    let mut total_bytes = 0u64;
+    let mut latest_modified_ns = before.identity.modified_ns;
+    while let Some(entry) = directory.next(cancel)? {
+        if captures.len() >= MAX_FILES || !safety::regular_evidence_metadata(&entry.meta) {
+            return Ok(None);
+        }
+        let Some(name) = entry.path.file_name().and_then(OsStr::to_str) else {
+            return Ok(None);
+        };
+        let Some((module, tag)) = name
+            .strip_suffix(".pyc")
+            .and_then(|name| name.rsplit_once(".cpython-"))
+        else {
+            return Ok(None);
+        };
+        let (version, optimization) = tag
+            .split_once(".opt-")
+            .map_or((tag, None), |(version, value)| (version, Some(value)));
+        if module.is_empty()
+            || module.starts_with('.')
+            || version.len() < 2
+            || version.len() > 4
+            || !version.bytes().all(|byte| byte.is_ascii_digit())
+            || !version.starts_with('3')
+            || optimization.is_some_and(|value| !matches!(value, "1" | "2"))
+        {
+            return Ok(None);
+        }
+        total_bytes = total_bytes.saturating_add(entry.meta.identity.size);
+        if entry.meta.identity.size > MAX_FILE_BYTES || total_bytes > MAX_TOTAL_BYTES {
+            return Ok(None);
+        }
+        let source_path = parent.join(format!("{module}.py"));
+        let Some(source) = safety::scope_metadata(root, &source_path, cancel)? else {
+            return Ok(None);
+        };
+        if !safety::regular_evidence_metadata(&source) {
+            return Ok(None);
+        }
+        let captured = safety::read_regular_bounded(&entry.path, cancel, MAX_FILE_BYTES)?;
+        if captured.identity != entry.meta.identity
+            || captured.bytes.len() < 16
+            || captured.bytes[2..4] != *b"\r\n"
+            || !(3400..=4000).contains(&u16::from_le_bytes(captured.bytes[..2].try_into().unwrap()))
+            || !matches!(
+                u32::from_le_bytes(captured.bytes[4..8].try_into().unwrap()),
+                0 | 1 | 3
+            )
+        {
+            return Ok(None);
+        }
+        latest_modified_ns = latest_modified_ns
+            .max(captured.identity.modified_ns)
+            .max(source.identity.modified_ns);
+        captures.push((
+            name.to_owned(),
+            captured.identity,
+            blake3::hash(&captured.bytes),
+            source.identity,
+        ));
+    }
+    directory.unchanged()?;
+    if captures.is_empty() || safety::scope_metadata(root, path, cancel)?.as_ref() != Some(&before)
+    {
+        return Ok(None);
+    }
+    captures.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut hash = blake3::Hasher::new();
+    hash.update(format!("pythoncache-v{RULE_VERSION}").as_bytes());
+    for (name, bytecode, digest, source) in captures {
+        hash.update(name.as_bytes());
+        hash.update(&serde_json::to_vec(&(bytecode, source)).map_err(|error| error.to_string())?);
+        hash.update(digest.as_bytes());
+    }
+    Ok(Some(Evidence {
+        kind: "pythoncache",
+        title: format!(
+            "{} Python bytecode cache",
+            parent.file_name().unwrap_or_default().to_string_lossy()
+        ),
+        explanation: "A Python bytecode cache containing only recognized CPython bytecode with corresponding local source files. Python can compile those files again when needed.",
+        consequence: "Close Python processes before moving this cache to Trash. The next import may take longer while Python recompiles it. Source files stay in place. Trash does not free space or earn chips.",
+        fingerprint: hash.finalize().to_hex().to_string(),
+        blocked: None,
+        latest_modified_ns,
+        quiet_days: recommendations::quiet_days("pythoncache"),
+        activity_root: Some(parent.to_path_buf()),
+    }))
 }
 
 fn evidence(
@@ -1428,6 +1546,9 @@ fn evidence_with_downloads_cached(
     cancel: &AtomicBool,
     caches: Option<&mut EvidenceCaches>,
 ) -> Result<Option<Evidence>> {
+    if let Some(kind) = recommendations::home_cache_candidate(root, path, meta.is_dir()) {
+        return Ok(everyday_evidence(path, meta, kind));
+    }
     if let Some(kind) = recommendations::library_candidate(root, path, meta.is_dir()) {
         return Ok(everyday_evidence(path, meta, kind));
     }
@@ -1443,7 +1564,7 @@ fn evidence_with_downloads_cached(
         match path.file_name().and_then(OsStr::to_str) {
             Some(
                 name @ ("node_modules" | "target" | ".venv" | "venv" | ".next" | ".nuxt" | ".turbo"
-                | ".parcel-cache"),
+                | ".parcel-cache" | "__pycache__"),
             ) => Some(name),
             Some(name) if crate::project_providers::recognizes_name(OsStr::new(name)) => Some(name),
             _ => return Ok(None),
@@ -1477,6 +1598,7 @@ fn evidence_with_downloads_cached(
                 })),
             },
             Some("target") => cargo_evidence(root, parent, path, cancel, caches),
+            Some("__pycache__") => python_cache_evidence(root, path, cancel),
             Some(".venv" | "venv") => venv_evidence(parent, path, cancel, caches),
             Some(".next" | ".nuxt" | ".turbo" | ".parcel-cache") => {
                 webcache_evidence(parent, path, cancel, caches)
@@ -1597,6 +1719,7 @@ pub(crate) fn artifact_component(name: &OsStr) -> bool {
                     | ".nuxt"
                     | ".turbo"
                     | ".parcel-cache"
+                    | "__pycache__"
             )
         )
 }
@@ -1613,7 +1736,7 @@ fn is_conditional_artifact_name(path: &Path) -> bool {
         .is_some_and(crate::project_providers::recognizes_name)
         || matches!(
             path.file_name().and_then(OsStr::to_str),
-            Some(".venv" | "venv" | ".next" | ".nuxt" | ".turbo" | ".parcel-cache")
+            Some(".venv" | "venv" | ".next" | ".nuxt" | ".turbo" | ".parcel-cache" | "__pycache__")
         )
 }
 
@@ -1868,9 +1991,15 @@ fn finish_artifact_review<F: FnMut(ScanBatch)>(
     if review.candidate.suggestion_eligible {
         stats.candidates += 1;
         stats.first_finding_ms.get_or_insert(stats.elapsed_ms);
-        review.candidate.explanation.push_str(&format!(
-            " At least {} MB is allocated locally. The {} have been unmodified for at least {} days.",
-            recommendations::minimum_bytes(review.found.kind) / 1_000_000,
+        if review.found.quiet_days == 0 {
+            review.candidate.explanation.push_str(&format!(
+                " At least {} is allocated locally. No known owning tool is active; this cache can be cleared after review without a waiting period.",
+                recommendations::minimum_size_label(review.found.kind),
+            ));
+        } else {
+            review.candidate.explanation.push_str(&format!(
+            " At least {} is allocated locally. The {} have been unmodified for at least {} days.",
+            recommendations::minimum_size_label(review.found.kind),
             if review.is_dir {
                 "contents and identification files"
             } else {
@@ -1878,6 +2007,7 @@ fn finish_artifact_review<F: FnMut(ScanBatch)>(
             },
             review.found.quiet_days
         ));
+        }
     } else {
         stats.skipped += 1;
         if let Some(reason) = quality_reason {
@@ -2065,7 +2195,7 @@ pub(crate) fn scan_with_options(
             .filter(|path| path.starts_with(selected))
             .collect();
         // Normal Home discovery still excludes Library before metadata. These
-        // three fixed, grant-anchored probes never enumerate other Library data.
+        // Fixed, grant-anchored probes admit only the recognized Library routes.
         // Reuse one session so hard-link accounting remains shared across lanes.
         if selected == root.path {
             lanes.push(root.path.clone());
@@ -2270,6 +2400,16 @@ impl ScanSession {
         if starts.len() > MAX_SCAN_LANES {
             return Err("The scan exceeds the bounded logical-lane limit".into());
         }
+        // The extra Home lanes have only fixed shallow corridors; cache leaves
+        // switch to the independent measurement stack. Reserve their five
+        // descriptors from the breadth frontier, retaining both measurement
+        // jobs so a large app cache cannot delay shallow project findings.
+        let shallow_frontier_limit = MAX_SHALLOW_FRONTIER
+            - if starts.len() == MAX_SCAN_LANES {
+                SUPPORT_DISCOVERY_DESCRIPTORS + SWIFTPM_DISCOVERY_DESCRIPTORS
+            } else {
+                0
+            };
         if scope.expected.is_some() && starts.len() != 1 {
             return Err("An exact refresh cannot span multiple logical lanes".into());
         }
@@ -2414,7 +2554,9 @@ impl ScanSession {
                         break;
                     };
                     let library = recommendations::library_area(root, &frame.directory.path);
+                    let home_logs = recommendations::home_log_scope(root, &frame.directory.path);
                     let next_entry = if library.is_some()
+                        || home_logs
                         || (mode == ScanMode::Suggestions
                             && !downloads
                                 .as_ref()
@@ -2422,7 +2564,9 @@ impl ScanSession {
                     {
                         let home_children =
                             root.kind == "home" && frame.directory.path == root.path;
-                        let step = if let Some((area, suffix)) = library {
+                        let step = if home_logs {
+                            frame.directory.next_library_discovery(cancel, false)
+                        } else if let Some((area, suffix)) = library {
                             frame.directory.next_library_discovery(
                                 cancel,
                                 area == recommendations::LibraryArea::Caches
@@ -2544,6 +2688,7 @@ impl ScanSession {
                 && is_dir
                 && entry.path != root.path
                 && is_artifact_name(&entry.path)
+                && recommendations::developer_cache_route(root, &entry.path).is_none()
                 && !is_conditional_artifact_name(&entry.path)
                 && !quiet_for(
                     entry.meta.identity.modified_ns,
@@ -2891,6 +3036,24 @@ impl ScanSession {
                     stats.errors += 1;
                     continue;
                 }
+                if depth >= SUPPORT_DISCOVERY_DESCRIPTORS
+                    && recommendations::library_area(root, &entry.path).is_some_and(|(area, _)| {
+                        area == recommendations::LibraryArea::ApplicationSupport
+                    })
+                {
+                    stats.skipped += 1;
+                    stats.errors += 1;
+                    continue;
+                }
+                if depth >= SWIFTPM_DISCOVERY_DESCRIPTORS
+                    && starts.get(lane).is_some_and(|path| {
+                        *path == root.path.join(recommendations::SWIFTPM_CACHE_ROUTE)
+                    })
+                {
+                    stats.skipped += 1;
+                    stats.errors += 1;
+                    continue;
+                }
                 let opened = match opened_directory {
                     Some(directory) => Ok(directory),
                     None if depth == 0 => Directory::open(&entry.path),
@@ -2907,7 +3070,7 @@ impl ScanSession {
                             classify: classify_children,
                             lane,
                         };
-                        if frontier.len() < MAX_SHALLOW_FRONTIER {
+                        if frontier.len() < shallow_frontier_limit {
                             frontier.push_back(frame);
                         } else {
                             frontier.push_front(frame);
@@ -6767,6 +6930,96 @@ mod tests {
                 suggestion_reason(&found, &measured, now).is_some(),
                 "{kind}"
             );
+        }
+    }
+
+    fn python_bytecode_fixture() -> (tempfile::TempDir, Root, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().canonicalize().unwrap().join("Home");
+        let project = home.join("Documents/python-project");
+        let cache = project.join("__pycache__");
+        std::fs::create_dir_all(&cache).unwrap();
+        std::fs::write(project.join("module.py"), b"value = 42\n").unwrap();
+        let mut bytecode = vec![0u8; 4_096];
+        bytecode[..4].copy_from_slice(&[0xf3, 0x0d, b'\r', b'\n']);
+        std::fs::write(cache.join("module.cpython-312.pyc"), bytecode).unwrap();
+        age_tree(&home, 8);
+        let root = safety::authorize(&home, "home").unwrap();
+        (temp, root, cache)
+    }
+
+    #[test]
+    fn python_bytecode_requires_matching_source_and_complete_verified_contents() {
+        let (_temp, root, cache) = python_bytecode_fixture();
+        let cancel = AtomicBool::new(false);
+        let original = python_cache_evidence(&root, &cache, &cancel)
+            .unwrap()
+            .unwrap();
+        assert_eq!(original.kind, "pythoncache");
+        assert!(!recommendations::permanent_kind(original.kind));
+        let (_, rows) = candidates_in_mode(&root, ScanMode::MetadataCoverage);
+        let mut candidate = rows
+            .into_iter()
+            .find(|candidate| candidate.path == cache)
+            .unwrap();
+        assert_eq!(candidate.kind, "pythoncache");
+        assert!(candidate.allocated_bytes >= 4_096 && candidate.file_count == 1);
+        assert!(!candidate.eligible_permanent && !candidate.provisional);
+        // The permanent-operation kind gate applies even if a stored/client
+        // candidate claims eligibility. It executes before any activity check.
+        candidate.blocked_reason = None;
+        candidate.eligible_permanent = true;
+        assert!(
+            revalidate(&root, &candidate, &cancel)
+                .unwrap_err()
+                .contains("Trash-only")
+        );
+
+        std::fs::write(cache.parent().unwrap().join("module.py"), b"value = 43\n").unwrap();
+        let changed = python_cache_evidence(&root, &cache, &cancel)
+            .unwrap()
+            .unwrap();
+        assert_ne!(changed.fingerprint, original.fingerprint);
+        assert!(changed.latest_modified_ns > original.latest_modified_ns);
+        assert_eq!(
+            python_cache_evidence(&root, &cache, &AtomicBool::new(true))
+                .err()
+                .unwrap(),
+            "Cancelled"
+        );
+    }
+
+    #[test]
+    fn python_bytecode_preserves_sources_mixed_content_and_redirected_entries() {
+        for variant in 0..7 {
+            let (_temp, root, cache) = python_bytecode_fixture();
+            let source = cache.parent().unwrap().join("module.py");
+            let bytecode = cache.join("module.cpython-312.pyc");
+            match variant {
+                0 => std::fs::write(cache.join("personal.txt"), b"preserve this file").unwrap(),
+                1 => std::fs::create_dir(cache.join("nested")).unwrap(),
+                2 => std::fs::remove_file(&source).unwrap(),
+                3 => std::fs::write(&bytecode, b"not bytecode").unwrap(),
+                4 => {
+                    let preserved = source.with_file_name("preserved.py");
+                    std::fs::rename(&source, &preserved).unwrap();
+                    std::os::unix::fs::symlink(&preserved, &source).unwrap();
+                }
+                5 => std::fs::hard_link(&bytecode, cache.parent().unwrap().join("shared.pyc"))
+                    .unwrap(),
+                6 => {
+                    let preserved = bytecode.with_file_name("preserved.pyc");
+                    std::fs::rename(&bytecode, &preserved).unwrap();
+                    std::os::unix::fs::symlink(&preserved, &bytecode).unwrap();
+                }
+                _ => unreachable!(),
+            }
+            let result = python_cache_evidence(&root, &cache, &AtomicBool::new(false));
+            assert!(
+                result.is_err() || result.unwrap().is_none(),
+                "variant {variant}"
+            );
+            assert!(cache.exists());
         }
     }
 

--- a/core/src/storage_inventory.rs
+++ b/core/src/storage_inventory.rs
@@ -1,0 +1,1640 @@
+//! Automatic, metadata-only inventory of specific storage locations.
+//!
+//! These observations are deliberately not candidates: they cannot authorize
+//! cleanup, report recovery, or earn chips. No installed commands run and no file
+//! contents are read. Defaults are inspected only when they exist; custom tool
+//! paths must be reviewed with the owning tool.
+
+use crate::model::{Identity, Root};
+use crate::safety::{self, EntryMeta};
+use serde::Serialize;
+use std::collections::HashSet;
+use std::ffi::{CStr, CString, OsStr, OsString};
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, Instant};
+
+const MAX_ISSUES: usize = 64;
+const MAX_PATH_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum InventoryState {
+    Complete,
+    Partial,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum CleanupAuthority {
+    ReviewOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum IssueKind {
+    PermissionDenied,
+    Symlink,
+    Changed,
+    DepthLimit,
+    EntryLimit,
+    TimeLimit,
+    CloudPlaceholder,
+    MountBoundary,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InventoryIssue {
+    pub path: PathBuf,
+    pub kind: IssueKind,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StorageInventoryRow {
+    pub id: String,
+    pub title: String,
+    pub category: String,
+    pub path: PathBuf,
+    pub state: InventoryState,
+    /// Observed allocation, deduplicated by inode within this location. APFS
+    /// clones and shared stores can share blocks: this is not recoverable space.
+    /// For a partial row this is only the measured portion, never a full total.
+    pub allocated_bytes: Option<u64>,
+    pub logical_bytes: Option<u64>,
+    pub files: u64,
+    pub directories: u64,
+    pub detail: String,
+    pub owner_followup: String,
+    /// An existing fixed owner-review destination, never an executable command.
+    pub provider: Option<String>,
+    pub cleanup_authority: CleanupAuthority,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StorageInventoryReport {
+    pub rows: Vec<StorageInventoryRow>,
+    pub issues: Vec<InventoryIssue>,
+    pub omitted_issues: u64,
+    pub examined_entries: u64,
+    pub elapsed_ms: u64,
+    /// Complete coverage of these fixed routes only, not the whole disk.
+    pub complete: bool,
+}
+
+#[derive(Clone, Copy)]
+struct Limits {
+    entries_per_route: u64,
+    total_entries: u64,
+    depth: usize,
+    route_time: Duration,
+    total_time: Duration,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            entries_per_route: 24_000,
+            total_entries: 160_000,
+            depth: 32,
+            route_time: Duration::from_millis(250),
+            total_time: Duration::from_secs(4),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Route {
+    id: &'static str,
+    title: &'static str,
+    category: &'static str,
+    relative: &'static str,
+    detail: &'static str,
+    followup: &'static str,
+    provider: Option<&'static str>,
+    /// Some locations are a single VM image. Never enumerate their data parent.
+    file_only: bool,
+    skip_children: &'static [&'static str],
+    /// A shallow metadata inventory, used for launch-agent plist filenames.
+    child_suffix: Option<&'static str>,
+}
+
+const fn route(
+    id: &'static str,
+    title: &'static str,
+    relative: &'static str,
+    followup: &'static str,
+) -> Route {
+    Route {
+        id,
+        title,
+        category: "Developer tools",
+        relative,
+        detail: "Storage at this standard location may still be in use. A custom tool location is not included.",
+        followup,
+        provider: None,
+        file_only: false,
+        skip_children: &[],
+        child_suffix: None,
+    }
+}
+
+const XCODE_REVIEW: &str = "Review in Xcode Settings and Devices and Simulators. Keep runtimes and build data needed by current projects.";
+const SYSTEM_REVIEW: &str = "macOS and the owning app manage these files. Review with the owner; this overview does not remove system files.";
+const VM_DETAIL: &str = "This disk image includes active containers, images, volumes, or machines. Its allocated size is not unused space; its logical size may be much larger.";
+
+// Review-only defaults outside the scanner's cleanup candidates. Do not add
+// cache or log routes already measured by discovery, or replace these with
+// recursive scans of .config, .local/share, Application Support, Containers,
+// or media folders.
+const USER_ROUTES: &[Route] = &[
+    route(
+        "rustup-downloads",
+        "Rust toolchain downloads",
+        ".rustup/downloads",
+        "Review downloads with rustup before removing anything an installation may still need.",
+    ),
+    Route {
+        detail: "These are installed Rust toolchains, including versions that projects may still require. No toolchain is classified as unused.",
+        ..route(
+            "rust-toolchains",
+            "Rust toolchains",
+            ".rustup/toolchains",
+            "Use rustup toolchain list and review project overrides before uninstalling a specific toolchain.",
+        )
+    },
+    Route {
+        category: "Containers",
+        detail: VM_DETAIL,
+        provider: Some("docker"),
+        file_only: true,
+        ..route(
+            "docker-disk",
+            "Docker Desktop disk image",
+            "Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw",
+            "Review Docker's disk usage to identify unused data. Never remove the VM disk image to clear a cache.",
+        )
+    },
+    Route {
+        category: "Containers",
+        detail: VM_DETAIL,
+        provider: Some("docker"),
+        file_only: true,
+        ..route(
+            "docker-disk-legacy",
+            "Docker Desktop disk image",
+            "Library/Containers/com.docker.docker/Data/vms/0/data/Docker.qcow2",
+            "Review Docker's disk usage to identify unused data. Never remove the VM disk image to clear a cache.",
+        )
+    },
+    Route {
+        category: "Containers",
+        detail: VM_DETAIL,
+        file_only: true,
+        ..route(
+            "orbstack-disk",
+            "OrbStack disk image",
+            "Library/Group Containers/HUAQ24HBR6.dev.orbstack/data/data.img",
+            "Use OrbStack to review containers and machines. Its virtual disk may contain important volumes and databases.",
+        )
+    },
+    Route {
+        category: "Containers",
+        detail: VM_DETAIL,
+        file_only: true,
+        ..route(
+            "orbstack-disk-raw",
+            "OrbStack disk image",
+            "Library/Group Containers/HUAQ24HBR6.dev.orbstack/data/data.img.raw",
+            "Use OrbStack to review containers and machines. Its virtual disk may contain important volumes and databases.",
+        )
+    },
+    Route {
+        category: "Containers",
+        detail: VM_DETAIL,
+        file_only: true,
+        ..route(
+            "orbstack-disk-legacy",
+            "OrbStack disk image",
+            ".orbstack/data/data.img",
+            "Use OrbStack to review containers and machines. Its virtual disk may contain important volumes and databases.",
+        )
+    },
+    Route {
+        detail: "Versioned Claude Code installations may include the current and previous versions. This inventory does not identify which versions are unused.",
+        ..route(
+            "claude-versions",
+            "Claude Code versions",
+            ".local/share/claude/versions",
+            "Review the active Claude Code version and its installation before changing versioned binaries.",
+        )
+    },
+    Route {
+        category: "Apps",
+        child_suffix: Some(".plist"),
+        detail: "These are user login-agent configuration files. This metadata-only overview does not inspect their configuration or establish that an app is missing.",
+        ..route(
+            "login-agents",
+            "Login items to review",
+            "Library/LaunchAgents",
+            "Review Login Items in System Settings and uninstall unwanted helpers through their owning apps. These entries are not classified as stale.",
+        )
+    },
+    route(
+        "simulator-cache",
+        "Simulator cache",
+        "Library/Developer/CoreSimulator/Caches",
+        XCODE_REVIEW,
+    ),
+    Route {
+        category: "Apps",
+        detail: "This exact CacheClip location may contain generated DaVinci Resolve render cache. Original media folders are not scanned by this overview.",
+        ..route(
+            "resolve-cache",
+            "DaVinci Resolve CacheClip",
+            "Movies/CacheClip",
+            "Use DaVinci Resolve's Delete Render Cache controls after reviewing the projects that use this cache.",
+        )
+    },
+];
+
+const SYSTEM_ROUTES: &[Route] = &[
+    Route {
+        category: "System",
+        ..route(
+            "system-caches",
+            "System caches",
+            "Library/Caches",
+            SYSTEM_REVIEW,
+        )
+    },
+    Route {
+        category: "System",
+        skip_children: &["DiagnosticReports"],
+        ..route(
+            "system-logs",
+            "System app logs",
+            "Library/Logs",
+            SYSTEM_REVIEW,
+        )
+    },
+    Route {
+        category: "System",
+        ..route(
+            "system-diagnostics",
+            "System diagnostic reports",
+            "Library/Logs/DiagnosticReports",
+            SYSTEM_REVIEW,
+        )
+    },
+    Route {
+        category: "System",
+        ..route(
+            "system-service-logs",
+            "System service logs",
+            "private/var/log",
+            SYSTEM_REVIEW,
+        )
+    },
+    route(
+        "simulator-system-cache",
+        "Simulator system cache",
+        "Library/Developer/CoreSimulator/Caches",
+        XCODE_REVIEW,
+    ),
+    route(
+        "simulator-images",
+        "Simulator runtime images",
+        "Library/Developer/CoreSimulator/Images",
+        XCODE_REVIEW,
+    ),
+    Route {
+        detail: "Mounted runtime volumes are excluded from traversal. Use Xcode to review installed runtimes and their storage.",
+        ..route(
+            "simulator-volumes",
+            "Simulator runtime volumes",
+            "Library/Developer/CoreSimulator/Volumes",
+            XCODE_REVIEW,
+        )
+    },
+    Route {
+        provider: Some("homebrew"),
+        ..route(
+            "homebrew-locks-arm",
+            "Homebrew lock files",
+            "opt/homebrew/var/homebrew/locks",
+            "Lock files may coordinate a running Homebrew operation. Review with Homebrew; age or a zero-byte size does not establish that a lock is stale.",
+        )
+    },
+    Route {
+        provider: Some("homebrew"),
+        ..route(
+            "homebrew-locks-intel",
+            "Homebrew lock files",
+            "usr/local/var/homebrew/locks",
+            "Lock files may coordinate a running Homebrew operation. Review with Homebrew; age or a zero-byte size does not establish that a lock is stale.",
+        )
+    },
+];
+
+/// The caller must validate an existing Home grant before this call and again
+/// before publishing its result. The opened descriptor must match that grant
+/// before any storage route is inspected. `include_system` is permitted only
+/// for the user's real Home grant. Fixtures pass false and touch no system path.
+pub fn scan(root: &Root, include_system: bool) -> StorageInventoryReport {
+    if root.kind != "home" {
+        let mut scan = Scan::new(Limits::default());
+        scan.issue(
+            &root.path,
+            Failure::new(
+                IssueKind::PermissionDenied,
+                "A home-folder grant is required for the storage overview.",
+            ),
+        );
+        return scan.finish();
+    }
+    scan_bound(
+        &root.path,
+        &root.identity,
+        include_system,
+        Limits::default(),
+    )
+}
+
+fn scan_bound(
+    home: &Path,
+    expected_home: &Identity,
+    include_system: bool,
+    limits: Limits,
+) -> StorageInventoryReport {
+    let mut scan = Scan::new(limits);
+    let _local_io = match safety::LocalOnlyIo::new() {
+        Ok(guard) => guard,
+        Err(detail) => {
+            scan.issue(home, Failure::new(IssueKind::Unavailable, detail));
+            return scan.finish();
+        }
+    };
+    let home_fd = match open_absolute_directory(home) {
+        Ok(fd) => fd,
+        Err(failure) => {
+            scan.issue(home, failure);
+            return scan.finish();
+        }
+    };
+    let home_meta = match stat_fd(home_fd.as_raw_fd()) {
+        Ok(meta) if meta.uid == unsafe { libc::geteuid() } => meta,
+        Ok(_) => {
+            scan.issue(
+                home,
+                Failure::new(
+                    IssueKind::PermissionDenied,
+                    "The home folder is owned by another user.",
+                ),
+            );
+            return scan.finish();
+        }
+        Err(failure) => {
+            scan.issue(home, failure);
+            return scan.finish();
+        }
+    };
+    if home_meta.identity.device != expected_home.device
+        || home_meta.identity.inode != expected_home.inode
+        || home_meta.identity.mode != expected_home.mode
+    {
+        scan.issue(
+            home,
+            Failure::new(
+                IssueKind::Changed,
+                "The authorized home folder was replaced. Choose the folder again before scanning.",
+            ),
+        );
+        return scan.finish();
+    }
+    for route in USER_ROUTES {
+        scan.measure(
+            home_fd.as_raw_fd(),
+            home,
+            route,
+            Some(home_meta.identity.device),
+            false,
+        );
+    }
+    // Production system routes exist only on macOS. Linux tests must never
+    // accidentally inspect the runner's /Library or /private/var directories.
+    #[cfg(target_os = "macos")]
+    if include_system {
+        match open_absolute_directory(Path::new("/")) {
+            Ok(root) => {
+                for route in SYSTEM_ROUTES {
+                    scan.measure(root.as_raw_fd(), Path::new("/"), route, None, true);
+                }
+            }
+            Err(failure) => scan.issue(Path::new("/"), failure),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = include_system;
+    // A detached descriptor does not establish that the authorized display
+    // path still names the same Home. Remove observations on replacement.
+    if open_absolute_directory(home)
+        .and_then(|fd| stat_fd(fd.as_raw_fd()))
+        .map_or(true, |current| !same_object(&home_meta, &current))
+    {
+        scan.report.rows.clear();
+        scan.issue(
+            home,
+            Failure::new(
+                IssueKind::Changed,
+                "The home folder moved or changed during the overview. Scan it again.",
+            ),
+        );
+    }
+    scan.finish()
+}
+
+struct Scan {
+    report: StorageInventoryReport,
+    start: Instant,
+    limits: Limits,
+}
+
+impl Scan {
+    fn new(limits: Limits) -> Self {
+        Self {
+            report: StorageInventoryReport {
+                rows: Vec::new(),
+                issues: Vec::new(),
+                omitted_issues: 0,
+                examined_entries: 0,
+                elapsed_ms: 0,
+                complete: true,
+            },
+            start: Instant::now(),
+            limits,
+        }
+    }
+
+    fn finish(mut self) -> StorageInventoryReport {
+        self.report.elapsed_ms = self.start.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        self.report
+    }
+
+    fn issue(&mut self, path: &Path, failure: Failure) {
+        self.report.complete = false;
+        if self.report.issues.len() < MAX_ISSUES {
+            self.report.issues.push(InventoryIssue {
+                path: path.to_path_buf(),
+                kind: failure.kind,
+                detail: failure.detail,
+            });
+        } else {
+            self.report.omitted_issues += 1;
+        }
+    }
+
+    fn checkpoint(&self, started: Instant, entries: u64) -> Result<(), Failure> {
+        // Deadlines bound cooperative filesystem work; a kernel call itself is
+        // not preempted. The paths are local and cloud materialization is off.
+        if self.start.elapsed() >= self.limits.total_time
+            || started.elapsed() >= self.limits.route_time
+        {
+            return Err(Failure::new(
+                IssueKind::TimeLimit,
+                "The overview reached its time limit. Only the measured portion is shown.",
+            ));
+        }
+        if self.report.examined_entries >= self.limits.total_entries
+            || entries >= self.limits.entries_per_route
+        {
+            return Err(Failure::new(
+                IssueKind::EntryLimit,
+                "The overview reached its entry limit. Only the measured portion is shown.",
+            ));
+        }
+        Ok(())
+    }
+
+    fn measure(
+        &mut self,
+        base: RawFd,
+        base_path: &Path,
+        route: &Route,
+        device: Option<u64>,
+        system: bool,
+    ) {
+        let path = base_path.join(route.relative);
+        let started = Instant::now();
+        if let Err(failure) = self.checkpoint(started, 0) {
+            self.issue(&path, failure);
+            return;
+        }
+        let location = match locate(base, Path::new(route.relative), device) {
+            Ok(Some(location)) => location,
+            Ok(None) => return,
+            Err(failure) => {
+                self.issue(&path, failure);
+                return;
+            }
+        };
+        self.report.examined_entries += 1;
+        let mut row = StorageInventoryRow {
+            id: route.id.into(),
+            title: route.title.into(),
+            category: route.category.into(),
+            path: path.clone(),
+            state: InventoryState::Complete,
+            allocated_bytes: Some(0),
+            logical_bytes: Some(0),
+            files: 0,
+            directories: 0,
+            detail: route.detail.into(),
+            owner_followup: route.followup.into(),
+            provider: route.provider.map(str::to_owned),
+            cleanup_authority: CleanupAuthority::ReviewOnly,
+        };
+        let valid_owner =
+            |meta: &EntryMeta| meta.uid == unsafe { libc::geteuid() } || (system && meta.uid == 0);
+        if !valid_owner(&location.meta) {
+            self.issue(
+                &path,
+                Failure::new(
+                    IssueKind::PermissionDenied,
+                    "This storage belongs to another user.",
+                ),
+            );
+            row.state = InventoryState::Unavailable;
+        } else if route.file_only {
+            if location.meta.is_file() {
+                row.files = 1;
+                row.allocated_bytes = Some(location.meta.allocated);
+                row.logical_bytes = Some(location.meta.identity.size);
+                if stat_at(location.parent.as_raw_fd(), &location.name)
+                    .map_or(true, |meta| meta != location.meta)
+                {
+                    self.issue(
+                        &path,
+                        Failure::new(
+                            IssueKind::Changed,
+                            "The file changed while its size was being read.",
+                        ),
+                    );
+                    row.state = InventoryState::Partial;
+                }
+            } else {
+                self.issue(
+                    &path,
+                    Failure::new(
+                        IssueKind::Unavailable,
+                        "The expected disk-image file has a different type.",
+                    ),
+                );
+                row.state = InventoryState::Unavailable;
+            }
+        } else if location.meta.is_dir() {
+            match Directory::open(
+                location.parent.as_raw_fd(),
+                &location.name,
+                &location.meta,
+                path.clone(),
+            ) {
+                Ok(root) => self.walk(root, &location, route, started, &valid_owner, &mut row),
+                Err(failure) => {
+                    self.issue(&path, failure);
+                    row.state = InventoryState::Unavailable;
+                }
+            }
+        } else {
+            self.issue(
+                &path,
+                Failure::new(
+                    IssueKind::Unavailable,
+                    "The expected storage folder has a different type.",
+                ),
+            );
+            row.state = InventoryState::Unavailable;
+        }
+        // The terminal parent descriptor can remain valid after an ancestor is
+        // renamed. Re-resolve the route from its original anchor before using
+        // that pathname as the label for this measurement.
+        if let Err(failure) =
+            verify_location(base, Path::new(route.relative), device, &location.meta)
+        {
+            self.issue(&path, failure);
+            row.state = InventoryState::Partial;
+            row.allocated_bytes = None;
+            row.logical_bytes = None;
+        }
+        if row.state == InventoryState::Unavailable
+            || (row.state == InventoryState::Partial && row.files == 0)
+        {
+            row.allocated_bytes = None;
+            row.logical_bytes = None;
+        }
+        // An empty, successfully inspected directory is not a suggestion. A
+        // zero-byte lock file is an actual observation and remains review-only.
+        if row.state != InventoryState::Complete || row.files > 0 {
+            self.report.rows.push(row);
+        }
+    }
+
+    fn walk(
+        &mut self,
+        root: Directory,
+        location: &Location,
+        route: &Route,
+        started: Instant,
+        valid_owner: &impl Fn(&EntryMeta) -> bool,
+        row: &mut StorageInventoryRow,
+    ) {
+        let device = location.meta.identity.device;
+        let mut stack = vec![root];
+        let mut inodes = HashSet::new();
+        let mut entries = 1;
+        while !stack.is_empty() {
+            if let Err(failure) = self.checkpoint(started, entries) {
+                self.issue(&row.path, failure);
+                row.state = InventoryState::Partial;
+                break;
+            }
+            let current = stack.last_mut().unwrap();
+            let name = match current.next_name() {
+                Ok(Some(name)) => name,
+                Ok(None) => {
+                    let finished = stack.pop().unwrap();
+                    let parent = stack
+                        .last()
+                        .map_or(location.parent.as_raw_fd(), Directory::fd);
+                    let current_name = if stack.is_empty() {
+                        &location.name
+                    } else {
+                        &finished.name
+                    };
+                    if stat_fd(finished.fd()).map_or(true, |meta| meta != finished.initial)
+                        || stat_at(parent, current_name)
+                            .map_or(true, |meta| meta != finished.initial)
+                    {
+                        self.issue(&finished.path, Failure::new(IssueKind::Changed, "This folder changed during the overview. Scan again for a fresh measurement."));
+                        row.state = InventoryState::Partial;
+                    }
+                    continue;
+                }
+                Err(failure) => {
+                    let path = current.path.clone();
+                    self.issue(&path, failure);
+                    row.state = InventoryState::Partial;
+                    stack.pop();
+                    continue;
+                }
+            };
+            entries += 1;
+            self.report.examined_entries += 1;
+            if stack.len() == 1
+                && route
+                    .skip_children
+                    .iter()
+                    .any(|skip| name == OsStr::new(skip))
+            {
+                continue;
+            }
+            if route
+                .child_suffix
+                .is_some_and(|suffix| !name.as_bytes().ends_with(suffix.as_bytes()))
+            {
+                continue;
+            }
+            let current = stack.last().unwrap();
+            let path = current.path.join(&name);
+            if path.as_os_str().len() > MAX_PATH_BYTES {
+                self.issue(
+                    &current.path,
+                    Failure::new(
+                        IssueKind::DepthLimit,
+                        "A nested path exceeded the overview's path limit.",
+                    ),
+                );
+                row.state = InventoryState::Partial;
+                continue;
+            }
+            let name_c =
+                CString::new(name.as_bytes()).expect("A directory name cannot contain NUL");
+            let metadata = match stat_at(current.fd(), &name_c)
+                .and_then(|meta| boundary(meta, Some(device)))
+            {
+                Ok(metadata) => metadata,
+                Err(failure) => {
+                    self.issue(&path, failure);
+                    row.state = InventoryState::Partial;
+                    continue;
+                }
+            };
+            if !valid_owner(&metadata) {
+                self.issue(
+                    &path,
+                    Failure::new(
+                        IssueKind::PermissionDenied,
+                        "An entry is owned by another user and was excluded.",
+                    ),
+                );
+                row.state = InventoryState::Partial;
+                continue;
+            }
+            if metadata.is_file() {
+                // The set is bounded by entries_per_route. Count aliases as
+                // entries but never double-count a hardlinked inode's bytes.
+                row.files += 1;
+                if inodes.insert((metadata.identity.device, metadata.identity.inode)) {
+                    let allocated = row.allocated_bytes.unwrap().checked_add(metadata.allocated);
+                    let logical = row
+                        .logical_bytes
+                        .unwrap()
+                        .checked_add(metadata.identity.size);
+                    match (allocated, logical) {
+                        (Some(allocated), Some(logical)) => {
+                            row.allocated_bytes = Some(allocated);
+                            row.logical_bytes = Some(logical);
+                        }
+                        _ => {
+                            self.issue(
+                                &path,
+                                Failure::new(
+                                    IssueKind::Unavailable,
+                                    "The storage measurement exceeded the supported size.",
+                                ),
+                            );
+                            row.state = InventoryState::Unavailable;
+                            break;
+                        }
+                    }
+                }
+            } else if metadata.is_dir() {
+                if route.child_suffix.is_some() {
+                    continue;
+                }
+                row.directories += 1;
+                if stack.len() >= self.limits.depth || safety::is_cloud_component(&name) {
+                    let kind = if safety::is_cloud_component(&name) {
+                        IssueKind::CloudPlaceholder
+                    } else {
+                        IssueKind::DepthLimit
+                    };
+                    self.issue(
+                        &path,
+                        Failure::new(
+                            kind,
+                            "This nested folder was excluded from the bounded local overview.",
+                        ),
+                    );
+                    row.state = InventoryState::Partial;
+                    continue;
+                }
+                match Directory::open(current.fd(), &name_c, &metadata, path.clone()) {
+                    Ok(directory) => stack.push(directory),
+                    Err(failure) => {
+                        self.issue(&path, failure);
+                        row.state = InventoryState::Partial;
+                    }
+                }
+            } else {
+                self.issue(
+                    &path,
+                    Failure::new(
+                        IssueKind::Unavailable,
+                        "A special filesystem entry was excluded.",
+                    ),
+                );
+                row.state = InventoryState::Partial;
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Failure {
+    kind: IssueKind,
+    detail: String,
+}
+
+impl Failure {
+    fn new(kind: IssueKind, detail: impl Into<String>) -> Self {
+        Self {
+            kind,
+            detail: detail.into(),
+        }
+    }
+    fn io(error: io::Error) -> Self {
+        let kind = match error.raw_os_error() {
+            Some(libc::EACCES | libc::EPERM) => IssueKind::PermissionDenied,
+            Some(libc::ELOOP) => IssueKind::Symlink,
+            Some(libc::ENOENT | libc::ENOTDIR) => IssueKind::Changed,
+            _ => IssueKind::Unavailable,
+        };
+        let detail = match kind {
+            IssueKind::PermissionDenied => {
+                "macOS did not allow this location to be read. Check folder access and Full Disk Access."
+            }
+            IssueKind::Symlink => "Symbolic links are not followed by the overview.",
+            IssueKind::Changed => "This location moved or changed during the overview.",
+            _ => "This location could not be measured.",
+        };
+        Self::new(kind, detail)
+    }
+}
+
+fn same_object(left: &EntryMeta, right: &EntryMeta) -> bool {
+    left.identity.device == right.identity.device
+        && left.identity.inode == right.identity.inode
+        && left.identity.mode == right.identity.mode
+        && left.uid == right.uid
+        && left.flags == right.flags
+}
+
+fn stat_fd(fd: RawFd) -> Result<EntryMeta, Failure> {
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstat(fd, &mut stat) } != 0 {
+        return Err(Failure::io(io::Error::last_os_error()));
+    }
+    Ok(EntryMeta::from_stat(&stat))
+}
+
+fn stat_at(fd: RawFd, name: &CStr) -> Result<EntryMeta, Failure> {
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstatat(fd, name.as_ptr(), &mut stat, libc::AT_SYMLINK_NOFOLLOW) } != 0 {
+        return Err(Failure::io(io::Error::last_os_error()));
+    }
+    Ok(EntryMeta::from_stat(&stat))
+}
+
+fn boundary(meta: EntryMeta, device: Option<u64>) -> Result<EntryMeta, Failure> {
+    if meta.is_symlink() {
+        return Err(Failure::new(
+            IssueKind::Symlink,
+            "Symbolic links are not followed by the overview.",
+        ));
+    }
+    if meta.is_dataless() {
+        return Err(Failure::new(
+            IssueKind::CloudPlaceholder,
+            "Cloud placeholders are excluded without downloading them.",
+        ));
+    }
+    if device.is_some_and(|device| meta.identity.device != device) {
+        return Err(Failure::new(
+            IssueKind::MountBoundary,
+            "A different storage volume was excluded. Review it with its owning app.",
+        ));
+    }
+    Ok(meta)
+}
+
+fn open_at(fd: RawFd, name: &CStr, search: bool) -> Result<OwnedFd, Failure> {
+    #[cfg(target_os = "macos")]
+    let access = if search {
+        libc::O_SEARCH
+    } else {
+        libc::O_RDONLY | libc::O_DIRECTORY
+    };
+    #[cfg(not(target_os = "macos"))]
+    let access = {
+        let _ = search;
+        libc::O_RDONLY | libc::O_DIRECTORY
+    };
+    let raw = unsafe {
+        libc::openat(
+            fd,
+            name.as_ptr(),
+            access | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return Err(Failure::io(io::Error::last_os_error()));
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+fn validate_directory(fd: RawFd, expected: &EntryMeta) -> Result<(), Failure> {
+    let actual = boundary(stat_fd(fd)?, Some(expected.identity.device))?;
+    if !actual.is_dir() || actual != *expected {
+        return Err(Failure::new(
+            IssueKind::Changed,
+            "A folder changed before it could be measured.",
+        ));
+    }
+    safety::cloud_directory_check(fd)
+        .map_err(|detail| Failure::new(IssueKind::CloudPlaceholder, detail))?;
+    #[cfg(target_os = "macos")]
+    {
+        let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+        if unsafe { libc::fstatfs(fd, &mut stat) } != 0 {
+            return Err(Failure::io(io::Error::last_os_error()));
+        }
+        if stat.f_flags & libc::MNT_LOCAL as u32 == 0 {
+            return Err(Failure::new(
+                IssueKind::MountBoundary,
+                "Network and remote storage are excluded.",
+            ));
+        }
+    }
+    Ok(())
+}
+
+struct Location {
+    parent: OwnedFd,
+    name: CString,
+    meta: EntryMeta,
+}
+
+fn verify_location(
+    base: RawFd,
+    relative: &Path,
+    device: Option<u64>,
+    expected: &EntryMeta,
+) -> Result<(), Failure> {
+    if locate(base, relative, device).is_ok_and(|location| {
+        location.is_some_and(|location| same_object(&location.meta, expected))
+    }) {
+        Ok(())
+    } else {
+        Err(Failure::new(
+            IssueKind::Changed,
+            "This storage location moved or changed. Its previous measurement is no longer associated with this path.",
+        ))
+    }
+}
+
+fn locate(base: RawFd, relative: &Path, device: Option<u64>) -> Result<Option<Location>, Failure> {
+    if relative.as_os_str().len() > MAX_PATH_BYTES {
+        return Err(Failure::new(
+            IssueKind::DepthLimit,
+            "This path exceeds the overview's path limit.",
+        ));
+    }
+    let names = relative
+        .components()
+        .map(|component| match component {
+            Component::Normal(name) => CString::new(name.as_bytes()).map_err(|_| {
+                Failure::new(IssueKind::Unavailable, "The path contains an invalid name.")
+            }),
+            _ => Err(Failure::new(
+                IssueKind::Unavailable,
+                "The overview requires an exact local path.",
+            )),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if names.is_empty() {
+        return Err(Failure::new(
+            IssueKind::Unavailable,
+            "An empty storage route is not allowed.",
+        ));
+    }
+    let mut parent = open_at(base, c".", true)?;
+    for (index, name) in names.iter().enumerate() {
+        // ENOENT is absence only on the initial, no-follow metadata lookup.
+        // Any failure after a presence observation is a changed/partial result.
+        let mut raw: libc::stat = unsafe { std::mem::zeroed() };
+        if unsafe {
+            libc::fstatat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                &mut raw,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } != 0
+        {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::ENOENT) {
+                return Ok(None);
+            }
+            return Err(Failure::io(error));
+        }
+        let meta = boundary(EntryMeta::from_stat(&raw), device)?;
+        if index + 1 == names.len() {
+            return Ok(Some(Location {
+                parent,
+                name: name.clone(),
+                meta,
+            }));
+        }
+        if !meta.is_dir() {
+            return Err(Failure::new(
+                IssueKind::Changed,
+                "A storage path component is no longer a folder.",
+            ));
+        }
+        let next = open_at(parent.as_raw_fd(), name, true)?;
+        validate_directory(next.as_raw_fd(), &meta)?;
+        parent = next;
+    }
+    unreachable!("Nonempty route returns its final location")
+}
+
+fn open_absolute_directory(path: &Path) -> Result<OwnedFd, Failure> {
+    if !path.is_absolute() || path.as_os_str().len() > MAX_PATH_BYTES {
+        return Err(Failure::new(
+            IssueKind::Unavailable,
+            "An absolute local home folder is required.",
+        ));
+    }
+    let root = open_at(libc::AT_FDCWD, c"/", true)?;
+    if path == Path::new("/") {
+        return Ok(root);
+    }
+    let relative = path
+        .strip_prefix("/")
+        .map_err(|_| Failure::new(IssueKind::Unavailable, "Invalid absolute folder path."))?;
+    let location = locate(root.as_raw_fd(), relative, None)?.ok_or_else(|| {
+        Failure::new(
+            IssueKind::Unavailable,
+            "The home folder is no longer available.",
+        )
+    })?;
+    let result = open_at(location.parent.as_raw_fd(), &location.name, true)?;
+    validate_directory(result.as_raw_fd(), &location.meta)?;
+    Ok(result)
+}
+
+struct Directory {
+    reader: *mut libc::DIR,
+    name: CString,
+    path: PathBuf,
+    initial: EntryMeta,
+}
+
+impl Directory {
+    fn open(
+        parent: RawFd,
+        name: &CStr,
+        expected: &EntryMeta,
+        path: PathBuf,
+    ) -> Result<Self, Failure> {
+        let fd = open_at(parent, name, false)?;
+        validate_directory(fd.as_raw_fd(), expected)?;
+        let reader = unsafe { libc::fdopendir(fd.as_raw_fd()) };
+        if reader.is_null() {
+            return Err(Failure::io(io::Error::last_os_error()));
+        }
+        let _ = fd.into_raw_fd(); // Ownership transfers only after fdopendir succeeds.
+        Ok(Self {
+            reader,
+            name: name.into(),
+            path,
+            initial: expected.clone(),
+        })
+    }
+    fn fd(&self) -> RawFd {
+        unsafe { libc::dirfd(self.reader) }
+    }
+    fn next_name(&mut self) -> Result<Option<OsString>, Failure> {
+        loop {
+            #[cfg(target_os = "macos")]
+            unsafe {
+                *libc::__error() = 0;
+            }
+            #[cfg(not(target_os = "macos"))]
+            unsafe {
+                *libc::__errno_location() = 0;
+            }
+            let entry = unsafe { libc::readdir(self.reader) };
+            if entry.is_null() {
+                let error = io::Error::last_os_error();
+                return if error.raw_os_error().unwrap_or(0) == 0 {
+                    Ok(None)
+                } else {
+                    Err(Failure::io(error))
+                };
+            }
+            let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+            if name != b"." && name != b".." {
+                return Ok(Some(OsString::from_vec(name.to_vec())));
+            }
+        }
+    }
+}
+
+impl Drop for Directory {
+    fn drop(&mut self) {
+        unsafe {
+            libc::closedir(self.reader);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+    use tempfile::TempDir;
+
+    fn fixture() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+    fn home(fixture: &TempDir) -> PathBuf {
+        fixture.path().canonicalize().unwrap()
+    }
+    fn put(home: &Path, path: &str, bytes: usize) -> PathBuf {
+        let path = home.join(path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, vec![b'x'; bytes]).unwrap();
+        path
+    }
+    fn relaxed() -> Limits {
+        Limits {
+            route_time: Duration::from_secs(5),
+            total_time: Duration::from_secs(10),
+            ..Limits::default()
+        }
+    }
+
+    fn scan_with_limits(
+        home: &Path,
+        include_system: bool,
+        limits: Limits,
+    ) -> StorageInventoryReport {
+        let expected = safety::metadata(home).unwrap().identity;
+        scan_bound(home, &expected, include_system, limits)
+    }
+
+    #[test]
+    fn replaced_home_cannot_be_scanned_under_an_earlier_grant() {
+        let fixture = fixture();
+        let parent = home(&fixture);
+        let home = parent.join("authorized-home");
+        fs::create_dir(&home).unwrap();
+        let root = Root {
+            id: "fixture-home".into(),
+            path: home.clone(),
+            kind: "home".into(),
+            identity: safety::metadata(&home).unwrap().identity,
+        };
+        fs::rename(&home, parent.join("original-home")).unwrap();
+        put(&home, ".rustup/toolchains/replacement-data", 1_000_000);
+        let report = scan(&root, false);
+        assert!(report.rows.is_empty());
+        assert_eq!(report.examined_entries, 0);
+        assert_eq!(report.issues.len(), 1);
+        assert_eq!(report.issues[0].kind, IssueKind::Changed);
+    }
+
+    #[test]
+    fn a_non_home_grant_cannot_authorize_inventory_routes() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        put(&home, ".rustup/toolchains/data", 1_000_000);
+        let root = Root {
+            id: "fixture-folder".into(),
+            path: home.clone(),
+            kind: "folder".into(),
+            identity: safety::metadata(&home).unwrap().identity,
+        };
+        let report = scan(&root, false);
+        assert!(report.rows.is_empty());
+        assert_eq!(report.examined_entries, 0);
+        assert_eq!(report.issues[0].kind, IssueKind::PermissionDenied);
+    }
+
+    #[test]
+    fn cloud_and_volume_boundaries_are_rejected_before_directory_enumeration() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        let metadata = safety::metadata(&home).unwrap();
+        let mut placeholder = metadata.clone();
+        placeholder.flags |= 0x4000_0000;
+        assert_eq!(
+            boundary(placeholder, None).unwrap_err().kind,
+            IssueKind::CloudPlaceholder
+        );
+        assert_eq!(
+            boundary(
+                metadata.clone(),
+                Some(metadata.identity.device.wrapping_add(1))
+            )
+            .unwrap_err()
+            .kind,
+            IssueKind::MountBoundary
+        );
+    }
+
+    #[test]
+    fn exact_defaults_measure_existing_files_without_inventorying_siblings() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        let toolchains = put(&home, ".rustup/toolchains/content/file", 7777);
+        put(&home, ".aws/credentials", 1_000_000);
+        put(&home, ".local/share/opencode/sessions/private", 1_000_000);
+        put(&home, "Movies/Originals/movie.mp4", 1_000_000);
+        put(
+            &home,
+            "Library/org.swift.swiftpm/security/private",
+            1_000_000,
+        );
+        let report = scan_with_limits(&home, false, relaxed());
+        assert!(report.complete, "{:?}", report.issues);
+        assert_eq!(report.rows.len(), 1);
+        let row = &report.rows[0];
+        assert_eq!(row.id, "rust-toolchains");
+        assert_eq!(row.logical_bytes, Some(7777));
+        assert_eq!(
+            row.allocated_bytes,
+            Some(fs::metadata(toolchains).unwrap().blocks() * 512)
+        );
+        assert_eq!(row.cleanup_authority, CleanupAuthority::ReviewOnly);
+    }
+
+    #[test]
+    fn scanner_owned_cache_and_log_routes_are_not_inventoried() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        for route in crate::recommendations::DEVELOPER_CACHE_ROUTES {
+            put(&home, &format!("{}/preserved", route.path), 1024);
+        }
+        for path in [
+            "Library/Caches/com.example.app",
+            "Library/Caches/com.google.GoogleUpdater",
+            "Library/Application Support/Google/GoogleUpdater/crx_cache",
+            "Library/Application Support/Slack/Cache",
+            "Library/Logs/com.example.app",
+            "Library/Developer/Xcode/DerivedData/example",
+            "Library/Caches/com.apple.dt.Xcode",
+            ".npm/_logs",
+            ".config/gcloud/logs",
+            ".azure/logs",
+            ".oh-my-zsh/cache",
+            ".cache/opencode",
+            ".cache/ghostty",
+        ] {
+            put(&home, &format!("{path}/preserved.log"), 1024);
+        }
+        let report = scan_with_limits(&home, false, relaxed());
+        assert!(report.complete, "{:?}", report.issues);
+        assert!(report.rows.is_empty());
+        assert!(report.issues.is_empty());
+        assert_eq!(report.examined_entries, 0);
+    }
+
+    #[test]
+    fn missing_and_empty_locations_do_not_create_suggestions_or_errors() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        fs::create_dir_all(home.join(".rustup/toolchains")).unwrap();
+        let report = scan_with_limits(&home, false, relaxed());
+        assert!(report.complete);
+        assert!(report.rows.is_empty());
+        assert!(report.issues.is_empty());
+    }
+
+    #[test]
+    fn symlink_roots_and_ancestors_cannot_escape_the_home() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        let outside = tempfile::tempdir().unwrap();
+        let target = outside.path().canonicalize().unwrap();
+        put(&target, "secret/file", 32_000);
+        fs::create_dir_all(home.join(".rustup")).unwrap();
+        symlink(target.join("secret"), home.join(".rustup/toolchains")).unwrap();
+        symlink(&target, home.join(".local")).unwrap();
+        let report = scan_with_limits(&home, false, relaxed());
+        assert!(report.rows.is_empty());
+        assert!(!report.complete);
+        assert!(
+            report
+                .issues
+                .iter()
+                .all(|issue| issue.kind == IssueKind::Symlink)
+        );
+    }
+
+    #[test]
+    fn nested_symlink_is_partial_and_never_contributes_target_bytes() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        put(&home, ".rustup/toolchains/local", 17);
+        let target = put(&home, "unrelated/secret", 8_000_000);
+        symlink(target, home.join(".rustup/toolchains/link")).unwrap();
+        let report = scan_with_limits(&home, false, relaxed());
+        let row = &report.rows[0];
+        assert_eq!(row.state, InventoryState::Partial);
+        assert_eq!(row.logical_bytes, Some(17));
+        assert_eq!(row.files, 1);
+        assert_eq!(report.issues[0].kind, IssueKind::Symlink);
+    }
+
+    #[test]
+    fn hardlinks_are_counted_once_and_sparse_file_allocation_is_not_logical_size() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        let first = put(&home, ".local/share/claude/versions/a", 8192);
+        fs::hard_link(&first, home.join(".local/share/claude/versions/b")).unwrap();
+        let image = put(
+            &home,
+            "Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw",
+            0,
+        );
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&image)
+            .unwrap()
+            .set_len(8_000_000_000)
+            .unwrap();
+        let report = scan_with_limits(&home, false, relaxed());
+        let versions = report
+            .rows
+            .iter()
+            .find(|row| row.id == "claude-versions")
+            .unwrap();
+        assert_eq!(versions.logical_bytes, Some(8192));
+        assert_eq!(versions.files, 2);
+        let docker = report
+            .rows
+            .iter()
+            .find(|row| row.id == "docker-disk")
+            .unwrap();
+        assert_eq!(docker.logical_bytes, Some(8_000_000_000));
+        assert_eq!(
+            docker.allocated_bytes,
+            Some(fs::metadata(image).unwrap().blocks() * 512)
+        );
+        assert!(docker.allocated_bytes.unwrap() < docker.logical_bytes.unwrap());
+        assert_eq!(docker.cleanup_authority, CleanupAuthority::ReviewOnly);
+    }
+
+    #[test]
+    fn entry_and_depth_limits_publish_only_partial_measurements() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        for n in 0..20 {
+            put(&home, &format!(".rustup/toolchains/{n}"), 100);
+        }
+        put(&home, ".local/share/claude/versions/a/b/c/d", 10_000);
+        let report = scan_with_limits(
+            &home,
+            false,
+            Limits {
+                entries_per_route: 3,
+                depth: 1,
+                ..relaxed()
+            },
+        );
+        assert!(!report.complete);
+        let toolchains = report
+            .rows
+            .iter()
+            .find(|row| row.id == "rust-toolchains")
+            .unwrap();
+        assert_eq!(toolchains.state, InventoryState::Partial);
+        assert!(toolchains.logical_bytes.unwrap() <= 200);
+        let versions = report
+            .rows
+            .iter()
+            .find(|row| row.id == "claude-versions")
+            .unwrap();
+        assert_eq!(versions.state, InventoryState::Partial);
+        assert_eq!(versions.allocated_bytes, None);
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.kind == IssueKind::DepthLimit)
+        );
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.kind == IssueKind::EntryLimit)
+        );
+    }
+
+    #[test]
+    fn global_entry_and_time_limits_do_not_turn_unvisited_routes_into_zeroes() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        put(&home, ".rustup/toolchains/one", 10);
+        put(&home, ".local/share/claude/versions/one", 10);
+        let entries = scan_with_limits(
+            &home,
+            false,
+            Limits {
+                total_entries: 1,
+                ..relaxed()
+            },
+        );
+        assert!(entries.examined_entries <= 1);
+        assert!(entries.rows.iter().all(|row| row.allocated_bytes.is_none()));
+        assert!(
+            entries
+                .issues
+                .iter()
+                .any(|issue| issue.kind == IssueKind::EntryLimit)
+        );
+        let time = scan_with_limits(
+            &home,
+            false,
+            Limits {
+                total_time: Duration::ZERO,
+                ..relaxed()
+            },
+        );
+        assert!(time.rows.is_empty());
+        assert_eq!(time.examined_entries, 0);
+        assert!(
+            time.issues
+                .iter()
+                .all(|issue| issue.kind == IssueKind::TimeLimit)
+        );
+    }
+
+    #[test]
+    fn inaccessible_root_is_unavailable_and_never_a_zero_byte_measurement() {
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let fixture = fixture();
+        let home = home(&fixture);
+        let file = put(&home, ".rustup/toolchains/secret", 1000);
+        let toolchains = file.parent().unwrap();
+        fs::set_permissions(toolchains, fs::Permissions::from_mode(0o000)).unwrap();
+        let report = scan_with_limits(&home, false, relaxed());
+        fs::set_permissions(toolchains, fs::Permissions::from_mode(0o700)).unwrap();
+        let row = report
+            .rows
+            .iter()
+            .find(|row| row.id == "rust-toolchains")
+            .unwrap();
+        assert_eq!(row.state, InventoryState::Unavailable);
+        assert_eq!(row.allocated_bytes, None);
+        assert_eq!(report.issues[0].kind, IssueKind::PermissionDenied);
+    }
+
+    #[test]
+    fn denied_descendant_keeps_other_measurement_partial() {
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let fixture = fixture();
+        let home = home(&fixture);
+        put(&home, ".rustup/toolchains/available", 11);
+        let secret = put(&home, ".rustup/toolchains/denied/secret", 9999);
+        fs::set_permissions(secret.parent().unwrap(), fs::Permissions::from_mode(0o000)).unwrap();
+        let report = scan_with_limits(&home, false, relaxed());
+        fs::set_permissions(secret.parent().unwrap(), fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(report.rows[0].state, InventoryState::Partial);
+        assert_eq!(report.rows[0].logical_bytes, Some(11));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.kind == IssueKind::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn issue_memory_is_bounded_even_for_many_excluded_entries() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        fs::create_dir_all(home.join(".rustup/toolchains")).unwrap();
+        for n in 0..100 {
+            symlink(
+                "/does-not-exist",
+                home.join(format!(".rustup/toolchains/{n}")),
+            )
+            .unwrap();
+        }
+        let report = scan_with_limits(&home, false, relaxed());
+        assert_eq!(report.issues.len(), MAX_ISSUES);
+        assert_eq!(report.omitted_issues, 100 - MAX_ISSUES as u64);
+        assert_eq!(report.rows[0].allocated_bytes, None);
+    }
+
+    #[test]
+    fn a_directory_replaced_by_a_link_cannot_be_opened_from_old_metadata() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        fs::create_dir(home.join("cache")).unwrap();
+        let parent = open_absolute_directory(&home).unwrap();
+        let before = stat_at(parent.as_raw_fd(), c"cache").unwrap();
+        fs::rename(home.join("cache"), home.join("old-cache")).unwrap();
+        symlink("/", home.join("cache")).unwrap();
+        assert!(
+            Directory::open(parent.as_raw_fd(), c"cache", &before, home.join("cache")).is_err()
+        );
+    }
+
+    #[test]
+    fn a_renamed_intermediate_ancestor_invalidates_the_display_path() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        put(&home, ".rustup/toolchains/original", 100);
+        let base = open_absolute_directory(&home).unwrap();
+        let before = locate(base.as_raw_fd(), Path::new(".rustup/toolchains"), None)
+            .unwrap()
+            .unwrap();
+        fs::rename(home.join(".rustup"), home.join(".rustup-moved")).unwrap();
+        put(&home, ".rustup/toolchains/replacement", 10_000);
+        // The detached parent still resolves the original leaf, so checking
+        // that descriptor alone would falsely validate the display pathname.
+        assert_eq!(
+            stat_at(before.parent.as_raw_fd(), &before.name).unwrap(),
+            before.meta
+        );
+        let result = verify_location(
+            base.as_raw_fd(),
+            Path::new(".rustup/toolchains"),
+            None,
+            &before.meta,
+        );
+        assert_eq!(result.unwrap_err().kind, IssueKind::Changed);
+    }
+
+    #[test]
+    fn launch_agents_are_shallow_plist_observations_without_stale_claims() {
+        let fixture = fixture();
+        let home = home(&fixture);
+        put(&home, "Library/LaunchAgents/com.example.helper.plist", 23);
+        put(&home, "Library/LaunchAgents/.DS_Store", 900);
+        put(&home, "Library/LaunchAgents/unrelated/nested.plist", 900);
+        let report = scan_with_limits(&home, false, relaxed());
+        assert!(report.complete);
+        assert_eq!(report.rows[0].id, "login-agents");
+        assert_eq!(report.rows[0].logical_bytes, Some(23));
+        assert_eq!(report.rows[0].files, 1);
+        assert!(!report.rows[0].title.contains("stale"));
+    }
+
+    #[test]
+    fn fixed_routes_are_unique_narrow_and_serialized_without_cleanup_authority() {
+        let mut ids = HashSet::new();
+        for routes in [USER_ROUTES, SYSTEM_ROUTES] {
+            for route in routes {
+                assert!(ids.insert(route.id));
+                assert!(
+                    Path::new(route.relative)
+                        .components()
+                        .all(|part| matches!(part, Component::Normal(_)))
+                );
+                assert!(!matches!(
+                    route.relative,
+                    "Library"
+                        | "Library/Application Support"
+                        | "Library/Containers"
+                        | "Movies"
+                        | ".aws"
+                        | ".config"
+                        | ".local/share"
+                ));
+                assert!(
+                    route
+                        .provider
+                        .is_none_or(|provider| matches!(provider, "homebrew" | "uv" | "docker"))
+                );
+            }
+        }
+        let fixture = fixture();
+        let home = home(&fixture);
+        for route in USER_ROUTES {
+            for candidate in crate::recommendations::DEVELOPER_CACHE_ROUTES {
+                let observed = Path::new(route.relative);
+                let candidate = Path::new(candidate.path);
+                assert!(
+                    !observed.starts_with(candidate) && !candidate.starts_with(observed),
+                    "Inventory must not duplicate a scanner-owned developer cache: {}",
+                    route.relative
+                );
+            }
+            if route.file_only {
+                put(&home, route.relative, 1);
+            } else {
+                put(
+                    &home,
+                    &format!(
+                        "{}/fixture{}",
+                        route.relative,
+                        route.child_suffix.unwrap_or("")
+                    ),
+                    1,
+                );
+            }
+        }
+        let report = scan_with_limits(&home, false, relaxed());
+        assert!(report.complete, "{:?}", report.issues);
+        assert_eq!(report.rows.len(), USER_ROUTES.len());
+        assert!(
+            report
+                .rows
+                .iter()
+                .all(|row| row.cleanup_authority == CleanupAuthority::ReviewOnly)
+        );
+        assert!(report.rows.iter().all(|row| row.path.starts_with(&home)));
+        let json = serde_json::to_value(&report).unwrap();
+        assert!(json.get("recovery_bytes").is_none());
+        assert!(json.get("cleanup").is_none());
+        assert!(
+            json["rows"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|row| row["cleanup_authority"] == "ReviewOnly")
+        );
+    }
+}

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -101,6 +101,29 @@ static SUGGESTIONS_SQL: LazyLock<String> = LazyLock::new(|| {
     )
 });
 
+// Busy or protected developer caches remain visible with their exact reason.
+// They never enter the suggestion index and cannot authorize either operation.
+static BLOCKED_DEVELOPER_CACHES_SQL: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "SELECT c.json FROM candidates c
+    WHERE json_extract(c.json,'$.kind')='devcache'
+      AND json_extract(c.json,'$.suggestion_eligible')=0
+      AND json_extract(c.json,'$.eligible_permanent')=0
+      AND json_extract(c.json,'$.blocked_reason') IS NOT NULL
+      AND COALESCE(json_extract(c.json,'$.provisional'),0)=0
+      AND (json_extract(c.json,'$.allocated_bytes')>={}
+           OR (json_extract(c.json,'$.allocated_bytes')=0
+               AND json_extract(c.json,'$.file_count')=0
+               AND json_extract(c.json,'$.fingerprint')=''))
+      AND NOT EXISTS(SELECT 1 FROM kept k WHERE c.path=k.path
+          OR substr(c.path,1,length(k.path)+1)=k.path||'/'
+          OR substr(k.path,1,length(c.path)+1)=c.path||'/')
+    ORDER BY json_extract(c.json,'$.allocated_bytes') DESC, c.path
+    LIMIT 500",
+        crate::recommendations::minimum_size_sql("c.json"),
+    )
+});
+
 /// One page of the operations ledger, newest first. `?1` NULL starts at the
 /// newest receipt; a `next_before` cursor value continues strictly older ones.
 const HISTORY_PAGE_SQL: &str = "SELECT rowid, receipt_json FROM operations
@@ -117,6 +140,7 @@ impl Store {
         conn.execute_batch(&format!("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; PRAGMA foreign_keys=ON;
             PRAGMA wal_autocheckpoint={WAL_AUTOCHECKPOINT_PAGES}; PRAGMA journal_size_limit={WAL_SIZE_HINT_BYTES};
             CREATE TABLE IF NOT EXISTS roots(id TEXT PRIMARY KEY, path TEXT UNIQUE NOT NULL, json TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS root_anchors(root_id TEXT PRIMARY KEY REFERENCES roots(id) ON DELETE CASCADE, json TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS candidates(id TEXT PRIMARY KEY, root_id TEXT NOT NULL, path TEXT UNIQUE NOT NULL, json TEXT NOT NULL);
             CREATE INDEX IF NOT EXISTS candidate_roots ON candidates(root_id);
             CREATE TABLE IF NOT EXISTS kept(path TEXT PRIMARY KEY);
@@ -135,13 +159,29 @@ impl Store {
             DROP INDEX IF EXISTS candidate_suggestions_v2;
             DROP INDEX IF EXISTS candidate_suggestions_v3;
             DROP INDEX IF EXISTS candidate_suggestions_v4;
-            CREATE INDEX IF NOT EXISTS candidate_suggestions_v5 ON candidates(
+            DROP INDEX IF EXISTS candidate_suggestions_v5;
+            CREATE INDEX IF NOT EXISTS candidate_suggestions_v6 ON candidates(
                 {},
                 json_extract(json,'$.allocated_bytes') DESC, path)
                 WHERE json_extract(json,'$.suggestion_eligible')=1
                   AND json_extract(json,'$.blocked_reason') IS NULL
                   AND json_extract(json,'$.allocated_bytes')>={};",
             crate::recommendations::priority_sql("json"),
+            crate::recommendations::minimum_size_sql("json")
+        ))
+        .map_err(err)?;
+        conn.execute_batch(&format!(
+            "CREATE INDEX IF NOT EXISTS candidate_blocked_devcaches_v1 ON candidates(
+                json_extract(json,'$.allocated_bytes') DESC, path)
+                WHERE json_extract(json,'$.kind')='devcache'
+                  AND json_extract(json,'$.suggestion_eligible')=0
+                  AND json_extract(json,'$.eligible_permanent')=0
+                  AND json_extract(json,'$.blocked_reason') IS NOT NULL
+                  AND COALESCE(json_extract(json,'$.provisional'),0)=0
+                  AND (json_extract(json,'$.allocated_bytes')>={}
+                       OR (json_extract(json,'$.allocated_bytes')=0
+                           AND json_extract(json,'$.file_count')=0
+                           AND json_extract(json,'$.fingerprint')=''));",
             crate::recommendations::minimum_size_sql("json")
         ))
         .map_err(err)?;
@@ -479,6 +519,28 @@ impl Store {
         self.json_rows("SELECT json FROM roots ORDER BY path")
     }
 
+    pub(crate) fn root_anchor(&self, id: &str) -> Result<Option<RootAnchor>> {
+        let json: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT json FROM root_anchors WHERE root_id=?1",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(err)?;
+        json.map(|json| serde_json::from_str(&json).map_err(err))
+            .transpose()
+    }
+
+    pub(crate) fn save_root_anchor(&self, id: &str, anchor: &RootAnchor) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO root_anchors(root_id,json) VALUES(?1,?2) ON CONFLICT(root_id) DO UPDATE SET json=excluded.json",
+            params![id, serde_json::to_string(anchor).map_err(err)?],
+        ).map_err(err)?;
+        Ok(())
+    }
+
     /// Reconcile an event-history loss boundary atomically. The caller must
     /// have created `event_cursor` during engine initialization. Every root is
     /// re-enqueued before the cursor is advanced, so a failed queue write
@@ -610,9 +672,49 @@ impl Store {
     /// An explicit broader authorization replaces its contained scan roots atomically.
     /// History, kept paths and the reward ledger retain their original identities.
     pub fn authorize_root(&mut self, root: &Root, replace_contained: bool) -> Result<Vec<String>> {
+        self.authorize_root_with_anchor(root, replace_contained, None)
+    }
+
+    pub(crate) fn authorize_root_with_anchor(
+        &mut self,
+        root: &Root,
+        replace_contained: bool,
+        anchor: Option<&RootAnchor>,
+    ) -> Result<Vec<String>> {
+        self.authorize_root_impl(root, replace_contained, None, anchor)
+    }
+
+    /// The caller has freshly authorized this exact path. Replacement is
+    /// atomic even when the physical directory (and therefore grant ID) changed.
+    pub(crate) fn reauthorize_root(
+        &mut self,
+        root: &Root,
+        expected_id: &str,
+        anchor: Option<&RootAnchor>,
+    ) -> Result<Vec<String>> {
+        let previous = self.root(expected_id)?;
+        if previous.path != root.path {
+            return Err(
+                "Choose the same folder to renew its access, or add a new location.".into(),
+            );
+        }
+        self.authorize_root_impl(root, false, Some(expected_id), anchor)
+    }
+
+    fn authorize_root_impl(
+        &mut self,
+        root: &Root,
+        replace_contained: bool,
+        replace_exact: Option<&str>,
+        anchor: Option<&RootAnchor>,
+    ) -> Result<Vec<String>> {
         let mut contained = Vec::new();
         let mut narrowing_home = false;
         for existing in self.roots()? {
+            if replace_exact == Some(existing.id.as_str()) && existing.path == root.path {
+                contained.push(existing.id);
+                continue;
+            }
             // Reconfirming a legacy Home grant narrows its media policy. Replace
             // only the same physical grant, in the existing atomic transaction;
             // old candidate rows must not remain actionable during the refresh.
@@ -668,12 +770,19 @@ impl Store {
             ],
         )
         .map_err(err)?;
+        if let Some(anchor) = anchor {
+            tx.execute(
+                "INSERT INTO root_anchors(root_id,json) VALUES(?1,?2)",
+                params![root.id, serde_json::to_string(anchor).map_err(err)?],
+            )
+            .map_err(err)?;
+        }
         tx.execute(
             "INSERT OR IGNORE INTO incomplete_roots VALUES(?1)",
             [&root.id],
         )
         .map_err(err)?;
-        if narrowing_home {
+        if narrowing_home || replace_exact.is_some() {
             // The replacement scan belongs to the same commit as invalidation.
             // A restart between authorization and the native resume must not
             // leave the narrowed grant empty with no durable work to finish.
@@ -1400,7 +1509,15 @@ impl Store {
         if let Some(cached) = self.visible_candidates.borrow().as_ref() {
             return Ok(cached.clone());
         }
-        let candidates = self.json_rows::<Candidate>(&SUGGESTIONS_SQL)?;
+        let mut candidates = self.json_rows::<Candidate>(&SUGGESTIONS_SQL)?;
+        if candidates.len() < 500 {
+            let remaining = 500 - candidates.len();
+            candidates.extend(
+                self.json_rows::<Candidate>(&BLOCKED_DEVELOPER_CACHES_SQL)?
+                    .into_iter()
+                    .take(remaining),
+            );
+        }
         *self.visible_candidates.borrow_mut() = Some(candidates.clone());
         Ok(candidates)
     }
@@ -3675,6 +3792,113 @@ mod tests {
     }
 
     #[test]
+    fn real_unmeasured_busy_cache_stays_visible_and_never_prepares_cleanup() {
+        crate::activity::with_test_snapshot(
+            Ok(crate::activity::test_snapshot(&["/tools/node"], vec![])),
+            || {
+                let temp = tempfile::tempdir().unwrap();
+                let home = temp.path().canonicalize().unwrap().join("Home");
+                let cache = home.join(".npm/_cacache");
+                std::fs::create_dir_all(&cache).unwrap();
+                std::fs::write(cache.join("package"), [0x31; 8_192]).unwrap();
+                let root = crate::safety::authorize(&home, "home").unwrap();
+                let mut store = Store::open(&temp.path().join("state/library.sqlite")).unwrap();
+                store.add_root(&root).unwrap();
+                crate::scanner::scan(&root, None, &AtomicBool::new(false), |batch| {
+                    store.save_batch(&batch).unwrap();
+                })
+                .unwrap();
+                let rows = store.candidates().unwrap();
+                assert_eq!(rows.len(), 1);
+                let row = &rows[0];
+                assert_eq!(row.path, cache);
+                assert!(row.blocked_reason.as_ref().unwrap().contains("running"));
+                assert!(!row.provisional && !row.suggestion_eligible && !row.eligible_permanent);
+                assert_eq!((row.allocated_bytes, row.file_count), (0, 0));
+                assert!(row.fingerprint.is_empty());
+                assert!(crate::scanner::revalidate(&root, row, &AtomicBool::new(false)).is_err());
+                assert_eq!(std::fs::read(cache.join("package")).unwrap(), [0x31; 8_192]);
+                assert!(store.history().unwrap().is_empty());
+            },
+        );
+    }
+
+    #[test]
+    fn blocked_developer_caches_stay_visible_without_cleanup_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = Store::open(&dir.path().join("db")).unwrap();
+        let ready = item("ready", "/root/.npm/_cacache", "devcache", 8_192, true);
+        let mut busy = item("busy", "/root/.cache/uv", "devcache", 16_384, false);
+        busy.blocked_reason = Some("uv is running; close it and scan again".into());
+        busy.eligible_permanent = false;
+        let mut protected = busy.clone();
+        protected.id = "protected".into();
+        protected.path = "/root/.cargo/git/checkouts".into();
+        protected.blocked_reason = Some("Contains protected Git metadata".into());
+        let mut provisional = busy.clone();
+        provisional.id = "provisional".into();
+        provisional.path = "/root/.cache/pip".into();
+        provisional.provisional = true;
+        let mut other_kind = busy.clone();
+        other_kind.id = "other-kind".into();
+        other_kind.path = "/root/project/target".into();
+        other_kind.kind = "cargo".into();
+        let mut tiny = busy.clone();
+        tiny.id = "tiny".into();
+        tiny.path = "/root/.cache/ruff".into();
+        tiny.allocated_bytes = 1;
+        save(
+            &mut store,
+            vec![
+                ready.clone(),
+                busy.clone(),
+                protected.clone(),
+                provisional,
+                other_kind,
+                tiny,
+            ],
+        );
+        let visible = store.candidates().unwrap();
+        assert_eq!(
+            visible
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            ["ready", "busy", "protected"]
+        );
+        assert!(visible[0].suggestion_eligible && visible[0].eligible_permanent);
+        assert!(visible[1..].iter().all(|row| !row.suggestion_eligible
+            && !row.eligible_permanent
+            && row.blocked_reason.is_some()));
+        store.keep("/root/.cache", true).unwrap();
+        assert_eq!(
+            store
+                .candidates()
+                .unwrap()
+                .iter()
+                .map(|row| row.id.as_str())
+                .collect::<Vec<_>>(),
+            ["ready", "protected"]
+        );
+        assert!(store.wallet().unwrap().credited_bytes == 0 && store.history().unwrap().is_empty());
+        let plan: Vec<String> = store
+            .conn
+            .prepare(&format!(
+                "EXPLAIN QUERY PLAN {}",
+                *BLOCKED_DEVELOPER_CACHES_SQL
+            ))
+            .unwrap()
+            .query_map([], |row| row.get(3))
+            .unwrap()
+            .map(|row| row.unwrap())
+            .collect();
+        assert!(
+            plan.join(" ").contains("candidate_blocked_devcaches_v1"),
+            "{plan:?}"
+        );
+    }
+
+    #[test]
     fn ranking_only_returns_verified_meaningful_suggestions_and_respects_keep() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = Store::open(&dir.path().join("db")).unwrap();
@@ -3768,8 +3992,8 @@ mod tests {
                 .map(|row| row.kind.as_str())
                 .collect::<Vec<_>>(),
             [
-                "log",
                 "crashreport",
+                "log",
                 "cache",
                 "xcode",
                 "installer",
@@ -3778,11 +4002,12 @@ mod tests {
                 "largefile"
             ]
         );
-        // The 1 MB report and 10 MB log survive the query's size filter, while
+        // Small reports and logs survive their category-specific size filter,
+        // ordered by path when their size and priority match, while
         // a 500 MB personal file cannot displace first-group cleanup artifacts.
         assert_eq!(
             store.candidate("crashreport").unwrap().allocated_bytes,
-            1_000_000
+            crate::recommendations::minimum_bytes("crashreport")
         );
     }
 
@@ -4227,7 +4452,7 @@ mod tests {
             .map(|r| r.unwrap())
             .collect::<Vec<_>>()
             .join("\n");
-        assert!(details.contains("candidate_suggestions_v5"), "{details}");
+        assert!(details.contains("candidate_suggestions_v6"), "{details}");
         assert!(!details.contains("USE TEMP B-TREE"), "{details}");
     }
     #[test]
@@ -4351,6 +4576,84 @@ mod tests {
         assert_eq!(
             restarted.take_scope().unwrap(),
             Some(("root".into(), "/root".into()))
+        );
+    }
+
+    #[test]
+    fn exact_reauthorization_is_atomic_and_preserves_durable_choices() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = Store::open(&dir.path().join("db")).unwrap();
+        discovery_root(&mut store);
+        let old = store.root("root").unwrap();
+        let candidate = item("old", "/root/target", "cargo", 100_000_000, true);
+        save(&mut store, vec![candidate.clone()]);
+        store.keep("/root/preserve", true).unwrap();
+        store
+            .conn
+            .execute(
+                "UPDATE wallet SET collected=17,remainder=42,credited=1700000042",
+                [],
+            )
+            .unwrap();
+        let anchor = RootAnchor {
+            volume_uuid: [7; 16],
+            birth_seconds: 123,
+            birth_nanoseconds: 456,
+        };
+        store.save_root_anchor(&old.id, &anchor).unwrap();
+        let mut renewed = old.clone();
+        renewed.id = "renewed".into();
+        renewed.identity.device += 1;
+        let context = store.foreground_context().unwrap();
+        let summary = terminal_summary(10);
+        store.save_foreground_summary(context, &summary).unwrap();
+
+        let mut wrong_path = renewed.clone();
+        wrong_path.path = "/different".into();
+        assert!(
+            store
+                .reauthorize_root(&wrong_path, "root", Some(&anchor))
+                .is_err()
+        );
+        assert!(
+            store
+                .reauthorize_root(&renewed, "unknown", Some(&anchor))
+                .is_err()
+        );
+        store.conn.execute_batch("CREATE TEMP TRIGGER fail_reauthorize BEFORE INSERT ON root_anchors BEGIN SELECT RAISE(ABORT,'disposable anchor failure'); END;").unwrap();
+        assert!(
+            store
+                .reauthorize_root(&renewed, "root", Some(&anchor))
+                .is_err()
+        );
+        assert!(store.root("root").is_ok());
+        assert!(store.root("renewed").is_err());
+        assert_eq!(store.candidate("old").unwrap(), candidate);
+        assert_eq!(store.root_anchor("root").unwrap(), Some(anchor.clone()));
+        assert_eq!(store.foreground_context().unwrap(), context);
+        store
+            .conn
+            .execute_batch("DROP TRIGGER fail_reauthorize")
+            .unwrap();
+
+        assert_eq!(
+            store
+                .reauthorize_root(&renewed, "root", Some(&anchor))
+                .unwrap(),
+            ["root"]
+        );
+        assert!(store.root("root").is_err());
+        assert_eq!(store.root("renewed").unwrap().identity, renewed.identity);
+        assert!(store.candidates().unwrap().is_empty());
+        assert_eq!(store.root_anchor("root").unwrap(), None);
+        assert_eq!(store.root_anchor("renewed").unwrap(), Some(anchor));
+        assert_eq!(store.kept().unwrap(), ["/root/preserve"]);
+        assert_eq!(store.wallet().unwrap().collected_coins, 17);
+        assert_eq!(store.wallet().unwrap().fractional_bytes, 42);
+        assert!(store.load_foreground_summary().unwrap().is_none());
+        assert_eq!(
+            store.take_scope().unwrap(),
+            Some(("renewed".into(), "/root".into()))
         );
     }
 

--- a/core/tests/discovery.rs
+++ b/core/tests/discovery.rs
@@ -973,6 +973,125 @@ fn browser_cache_profiles_are_separate_reviews_and_refresh_independently() {
 }
 
 #[test]
+fn generated_app_and_tool_caches_are_discovered_without_entering_personal_state() {
+    let _engine_guard = support::engine_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let base = temp.path().canonicalize().unwrap();
+    let home = base.join("Home");
+    let units = [
+        ("Library/Application Support/Slack/Cache", "cache"),
+        ("Library/Application Support/Claude/Code Cache", "cache"),
+        (
+            "Library/Application Support/Google/GoogleUpdater/crx_cache",
+            "cache",
+        ),
+        (".cache/zig", "devcache"),
+        (".cache/opencode", "cache"),
+        (".expo/versions-cache", "devcache"),
+        (".npm/_cacache", "devcache"),
+        (".cache/uv", "devcache"),
+        ("Library/Caches/pip", "devcache"),
+        ("Library/org.swift.swiftpm/cache", "devcache"),
+        ("Library/Caches/Homebrew/downloads", "devcache"),
+        ("Library/Developer/Xcode/DerivedData/SmallProject", "xcode"),
+    ];
+    for (relative, _) in units {
+        allocated_file(&home.join(relative).join("payload"), 1_100_000);
+    }
+    let log = home.join(".npm/_logs/old.log");
+    allocated_file(&log, 8_192);
+    let protected = [
+        "Library/Application Support/Slack/Local Storage/state",
+        "Library/Application Support/Claude/claude-code/current",
+        "Library/Application Support/Google/Chrome/Default/Bookmarks",
+        "Library/Application Support/Unknown/Cache/payload",
+        ".npm/config/payload",
+        ".cargo/git/payload",
+        ".cache/unknown/payload",
+    ]
+    .map(|relative| home.join(relative));
+    for path in &protected {
+        allocated_file(path, 1_100_000);
+    }
+    age_fixture_tree(&home, 8);
+    // Two-day app caches must surface despite the former 30-day threshold.
+    for (relative, kind) in units {
+        if kind == "cache" {
+            age_fixture_tree(&home.join(relative), 2);
+        }
+    }
+    let db = base.join("db");
+    let engine = Engine::open(&db, None).unwrap();
+    let root: Root = serde_json::from_value(
+        engine
+            .request(json!({
+                "action":"authorize", "path":home, "kind":"home"
+            }))
+            .unwrap(),
+    )
+    .unwrap();
+    engine
+        .request(json!({"action":"scan", "metadata_coverage":true}))
+        .unwrap();
+    let initial = wait(&engine);
+    assert!(initial.stats.complete, "{initial:?}");
+    for (relative, kind) in units {
+        let candidate = indexed_candidate(&db, &home.join(relative));
+        assert_eq!(candidate.kind, kind, "{relative}");
+        assert!(
+            candidate.allocated_bytes >= 1_100_000 && !candidate.provisional,
+            "{candidate:?}"
+        );
+        assert_eq!(
+            candidate.eligible_permanent,
+            kind == "devcache" && candidate.suggestion_eligible
+        );
+        // Installed apps/build tools may be active on this host. Recognition,
+        // complete measurement and the narrow scope are independent of that.
+        if !candidate.suggestion_eligible {
+            assert!(candidate.blocked_reason.is_some(), "{candidate:?}");
+        }
+    }
+    let old_log = indexed_candidate(&db, &log);
+    assert_eq!(old_log.kind, "log");
+    assert!(old_log.suggestion_eligible && !old_log.eligible_permanent);
+    assert!(old_log.explanation.contains("4 KB"));
+    for path in &protected {
+        assert!(
+            initial
+                .candidates
+                .iter()
+                .all(|candidate| !path.starts_with(&candidate.path))
+        );
+        assert_eq!(fs::metadata(path).unwrap().len(), 1_100_000);
+    }
+
+    let cache = home.join(".expo/versions-cache");
+    let before = indexed_candidate(&db, &cache);
+    fs::write(cache.join("new"), b"recent generated data").unwrap();
+    engine
+        .request(json!({
+            "action":"dirty", "root_id":root.id,
+            "events":[{"path":cache.join("new"), "kind":"file", "recursive":false}]
+        }))
+        .unwrap();
+    let updated = wait(&engine);
+    assert!(updated.stats.complete);
+    let after = indexed_candidate(&db, &cache);
+    assert!(after.modified_ns > before.modified_ns);
+    assert_eq!(after.kind, "devcache");
+    assert_eq!(after.eligible_permanent, after.suggestion_eligible);
+    assert!(
+        !after.explanation.contains("quiet days"),
+        "Explicit cache cleanup has no age delay"
+    );
+    if !after.suggestion_eligible {
+        assert!(after.blocked_reason.is_some());
+    }
+    assert_eq!(indexed_candidate(&db, &log), old_log);
+}
+
+#[test]
 fn home_everyday_recommendations_are_scoped_freshness_checked_and_trash_only() {
     let _engine_guard = support::engine_guard();
     let temp = tempfile::tempdir().unwrap();
@@ -997,7 +1116,7 @@ fn home_everyday_recommendations_are_scoped_freshness_checked_and_trash_only() {
         "Library/Containers/fixture/Data/Library/Caches/preserve",
         "Library/Developer/Xcode/Archives/preserve",
         "Library/Developer/CoreSimulator/preserve",
-        "Library/Caches/uv/preserve",
+        "Library/Caches/pnpm/preserve",
         "Library/Caches/Homebrew/preserve",
     ]
     .map(|relative| home.join(relative));
@@ -1133,7 +1252,7 @@ fn home_everyday_recommendations_are_scoped_freshness_checked_and_trash_only() {
     let changed_cache = indexed_candidate(&db, &cache);
     assert!(changed_cache.modified_ns > cached_review.modified_ns);
     assert!(
-        changed_cache.explanation.contains("30 quiet days"),
+        changed_cache.explanation.contains("1 quiet days"),
         "Freshness must independently exclude the measured cache: {changed_cache:?}"
     );
     assert_eq!(fs::read(&active_payload).unwrap(), b"new work must remain");

--- a/native/Chippytea/DiskAccessView.swift
+++ b/native/Chippytea/DiskAccessView.swift
@@ -83,9 +83,10 @@ struct DiskAccessView: View {
             LookRoundSketch()
                 .frame(height: 150).frame(maxWidth: .infinity)
             title("Let chippytea have a look round.", seed: 703)
-            copy("To look through your home folder, macOS asks you to switch on Full Disk Access once. It’s quick: open Settings, drag chippytea in, switch it on.")
+            copy("Give chippytea access once to find cleanup opportunities across your Mac. Open Settings, drag chippytea in, then switch it on.")
             VStack(alignment: .leading, spacing: 6) {
-                dashed("Finds old caches, logs, build files, downloads and large personal files.", seed: 771)
+                dashed("Finds app and developer caches, logs, build files and downloads.", seed: 771)
+                dashed("Shows system and tool-managed storage to review, including locations that need an administrator.", seed: 772)
                 dashed("Leaves photo and music libraries alone.", seed: 773)
                 dashed("Removes nothing without your review.", seed: 775)
             }
@@ -192,7 +193,7 @@ struct DiskAccessView: View {
             Button(starting ? "Starting your scan…" : "It’s switched on — scan my Mac") { model.confirmDiskAccessAndScan() }
                 .buttonStyle(InkButtonStyle(kind: .primary, fullWidth: true, seed: 733))
                 .disabled(working || model.diskAccessPhase != .waiting)
-                .accessibilityHint("Confirms that you enabled Full Disk Access for this app in macOS and completed Quit & Reopen if asked, then starts your home-folder scan.")
+                .accessibilityHint("Confirms that you enabled Full Disk Access for this app in macOS and completed Quit & Reopen if asked, then scans your files and checks known system and developer storage locations.")
         }
     }
 

--- a/native/Chippytea/EngineBridge.swift
+++ b/native/Chippytea/EngineBridge.swift
@@ -157,6 +157,7 @@ final class EngineClient: @unchecked Sendable {
     private let queue = DispatchQueue(label: "app.chippytea.engine", qos: .utility)
     private let progressQueue = DispatchQueue(label: "app.chippytea.cleanup-progress", qos: .utility)
     private let managedReviewQueue = DispatchQueue(label: "app.chippytea.managed-review", qos: .utility)
+    private let inventoryQueue = DispatchQueue(label: "app.chippytea.storage-inventory", qos: .utility)
     private let managedReviewAdmission = NSLock()
     private var managedReviewRunning = false
     private var conditionalSnapshotDecoder = ConditionalSnapshotDecoder()
@@ -169,6 +170,16 @@ final class EngineClient: @unchecked Sendable {
     func request(_ request: [String: Any]) async throws -> Data {
         try await withCheckedThrowingContinuation { continuation in
             queue.async { do { continuation.resume(returning: try self.requestSync(request)) } catch { continuation.resume(throwing: error) } }
+        }
+    }
+    func storageInventory(rootID: String) async throws -> StorageInventoryReportDTO {
+        try await withCheckedThrowingContinuation { continuation in
+            inventoryQueue.async {
+                do {
+                    let data = try self.requestSync(["action": "storage_inventory", "root_id": rootID])
+                    continuation.resume(returning: try StorageInventoryReportDTO.decode(data))
+                } catch { continuation.resume(throwing: error) }
+            }
         }
     }
     /// One explicitly requested owner-tool review has an independent queue so
@@ -437,6 +448,12 @@ struct DiscoveryPresentation: Equatable {
     /// Screenshot staging freezes the setup sketches at one moment of their loop.
     var diskAccessSceneTime: Double?
     @Published private(set) var diskAccessNeedsReplacement = false
+    @Published private(set) var rootAccessIssues: [RootAccessIssue] = []
+    @Published private(set) var storageInventory: StorageInventoryReportDTO?
+    @Published private(set) var inventoryLoading = false
+    @Published private(set) var inventoryError: String?
+    @Published var settingsSection = "scan-locations"
+    @Published var managedProvider: ManagedProviderID = .homebrew
     @Published var reviewItems: [Candidate] = []
     @Published var busy = false
     @Published var errorMessage: String?
@@ -503,8 +520,14 @@ struct DiscoveryPresentation: Equatable {
     private let directory: URL
     private let scanHome: URL
     private let readSnapshot: (EngineClient) async throws -> EngineSnapshot
+    private let readStorageInventory: (EngineClient, String) async throws -> StorageInventoryReportDTO
     private var bookmarks: [String: Data] = [:]
-    private var accesses: [URL] = []
+    private var bookmarkIssues: [String: RootAccessIssue] = [:]
+    private var rootAccessRequestID: UInt64 = 0
+    private var appliedRootAccessRequestID: UInt64 = 0
+    private var rootAccessWarning: String?
+    private var inventoryGeneration: UInt64 = 0
+    private var accesses: [(path: String, url: URL)] = []
     private var watcher: FolderWatcher?
     private var pollTask: Task<Void, Never>?
     private(set) var pollDemandID: UInt64 = 0
@@ -548,12 +571,14 @@ struct DiscoveryPresentation: Equatable {
     private var diskAccessRevision = 0
 
     init(directory: URL? = nil, scanHome: URL? = nil,
+         readStorageInventory: @escaping (EngineClient, String) async throws -> StorageInventoryReportDTO = { try await $0.storageInventory(rootID: $1) },
          readSnapshot: @escaping (EngineClient) async throws -> EngineSnapshot = { try await $0.snapshot() }) {
         let testDirectory = ProcessInfo.processInfo.environment["CHIPPYTEA_DATA_DIR"].map { URL(fileURLWithPath: $0, isDirectory: true) }
         self.directory = directory ?? testDirectory
             ?? Self.stateDirectory(in: FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0])
         self.scanHome = scanHome ?? FileManager.default.homeDirectoryForCurrentUser
         self.readSnapshot = readSnapshot
+        self.readStorageInventory = readStorageInventory
         backgroundActivityObservation = snapshotSubject.map(\.scanning).removeDuplicates()
             .sink { [weak self] scanning in self?.scanningActivityChanged(scanning) }
     }
@@ -822,7 +847,9 @@ struct DiscoveryPresentation: Equatable {
             await reload()
             for root in snapshot.roots {
                 guard let data = bookmarks[root.path] else {
-                    _ = try await client?.request(["action": "forget", "id": root.id]); continue
+                    bookmarkIssues[root.id] = RootAccessIssue(rootId: root.id, path: root.path,
+                        status: "reauthorization_required", message: "Reconnect this folder to restore its saved access.")
+                    continue
                 }
                 do {
                     var stale = false
@@ -835,11 +862,23 @@ struct DiscoveryPresentation: Equatable {
                         scoped = false
                         url = try URL(resolvingBookmarkData: data, options: [.withoutUI, .withoutMounting], relativeTo: nil, bookmarkDataIsStale: &stale)
                     }
-                    guard !stale, url.path == root.path else { throw EngineError.message("Choose \(root.name) again to renew folder access.") }
-                    if scoped { _ = url.startAccessingSecurityScopedResource(); accesses.append(url) }
-                } catch { _ = try await client?.request(["action": "forget", "id": root.id]); errorMessage = error.localizedDescription }
+                    guard try Self.physicalFolderPath(url) == root.path else { throw EngineError.message("Reconnect \(root.name) to confirm its location.") }
+                    if scoped { _ = url.startAccessingSecurityScopedResource(); accesses.append((root.path, url)) }
+                    // A stale bookmark may still resolve the same physical folder.
+                    // The engine's durable volume identity decides whether it is
+                    // still the authorized object before any scan can use it.
+                    if stale {
+                        bookmarks[root.path] = try url.bookmarkData(options: scoped ? [.withSecurityScope] : [],
+                            includingResourceValuesForKeys: nil, relativeTo: nil)
+                        try saveBookmarks()
+                    }
+                } catch {
+                    bookmarkIssues[root.id] = RootAccessIssue(rootId: root.id, path: root.path,
+                        status: "reauthorization_required", message: error.localizedDescription)
+                }
             }
             await reload()
+            await checkRootAccess()
             if completedAccessMatches && diskAccessRevision == accessRevisionAtStart {
                 let home = scanHome
                 let blocked = await Task.detached(priority: .utility) {
@@ -850,7 +889,8 @@ struct DiscoveryPresentation: Equatable {
                         // Older builds stored Home as an unrestricted folder.
                         // Narrow the same physical grant atomically before any
                         // watcher or pending scan can use its old media policy.
-                        if snapshot.roots.contains(where: { $0.path == homePath && $0.kind == "folder" }) {
+                        if let legacy = snapshot.roots.first(where: { $0.path == homePath && $0.kind == "folder" }),
+                           !rootAccessIssues.contains(where: { $0.rootId == legacy.id }) {
                             _ = try await client?.request(["action": "authorize", "path": homePath, "kind": "home", "replace_contained": true])
                             await reload()
                             guard snapshot.roots.contains(where: { $0.path == homePath && $0.kind == "home" }) else {
@@ -876,11 +916,13 @@ struct DiscoveryPresentation: Equatable {
                 }
             }
             if let data = try await client?.request(["action": "cursor"]), let value = try JSONSerialization.jsonObject(with: data) as? [String: UInt64] { cursor = value["cursor"] ?? 0 }
+            await checkRootAccess()
             restoringAccess = false
             var needsInitialScan = false
             if accessRecord != .waiting || !showDiskAccess {
                 restartWatcher()
-                if diskAccessRevision == accessRevisionAtStart && !snapshot.roots.isEmpty && !(homeAuthorized && !diskAccessConfigured) {
+                if diskAccessRevision == accessRevisionAtStart && !snapshot.roots.isEmpty
+                    && rootAccessIssues.isEmpty && !(homeAuthorized && !diskAccessConfigured) {
                     if cursor == 0 { needsInitialScan = true }
                     else { _ = try await client?.request(["action": "resume"]); poll() }
                 }
@@ -890,6 +932,7 @@ struct DiscoveryPresentation: Equatable {
             // operation must not acquire busy before our defer clears it.
             busy = false
             if needsInitialScan { refresh() }
+            else { refreshStorageInventory() }
         } catch { errorMessage = error.localizedDescription }
     }
 
@@ -908,6 +951,7 @@ struct DiscoveryPresentation: Equatable {
                 lastObservedSnapshotReadError = nil
             }
             reconcileDuplicateReport(with: current)
+            if inventoryRoot(in: current) != inventoryRoot(in: snapshot) { invalidateStorageInventory() }
             if current != snapshot { snapshot = current }
             var presentation = discoveryPresentation
             if let boundary = acceptedScanSnapshotBoundary, requestID > boundary {
@@ -927,7 +971,10 @@ struct DiscoveryPresentation: Equatable {
             if let expanded = expandedSuggestion, !current.candidates.contains(where: { $0.id == expanded }) { expandedSuggestion = nil }
             if !presentation.isRequestPending && current.error != lastObservedEngineError {
                 lastObservedEngineError = current.error
-                if let error = current.error, errorMessage != error { errorMessage = error }
+                if let error = current.error {
+                    if errorMessage != error { errorMessage = error }
+                    Task { [weak self] in await self?.checkRootAccess() }
+                }
             }
             if lastNotifiedPendingCoins != current.wallet.pendingCoins {
                 lastNotifiedPendingCoins = current.wallet.pendingCoins
@@ -1091,7 +1138,7 @@ struct DiscoveryPresentation: Equatable {
         let revision = watcherRevision
         // One event can resume the engine's entire durable queue, including a
         // Home scope left by an older build. Keep all watching gated with Scan.
-        guard !restoringAccess, !(homeAuthorized && !diskAccessConfigured) else { return }
+        guard !restoringAccess, rootAccessIssues.isEmpty, !(homeAuthorized && !diskAccessConfigured) else { return }
         if cursor == 0 { pendingCursor = max(pendingCursor, FSEventsGetCurrentEventId()) }
         let roots = snapshot.roots.filter { diskAccessConfigured || $0.path != homePath }
         guard !roots.isEmpty else { return }
@@ -1112,49 +1159,160 @@ struct DiscoveryPresentation: Equatable {
     func beginSystemDialog() { systemDialogDepth += 1; onSystemDialogDepthChange?(systemDialogDepth) }
     func endSystemDialog() { systemDialogDepth = max(0, systemDialogDepth - 1); onSystemDialogDepthChange?(systemDialogDepth) }
 
-    func chooseFolder(kind: String) {
-        guard !busy, !snapshot.scanning else { return }
+    func chooseFolder(kind: String, reconnecting root: ScanRoot? = nil) {
+        guard !busy, !snapshot.scanning, !hasCleanupWork, systemDialogDepth == 0 else { return }
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true; panel.canChooseFiles = false; panel.allowsMultipleSelection = false
-        panel.prompt = "Allow this folder"
-        panel.message = "chippytea looks only inside folders you choose. Nothing is selected for cleanup automatically."
-        if kind == "downloads" { panel.directoryURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first }
+        panel.prompt = root == nil ? "Allow this folder" : "Reconnect folder"
+        panel.message = root.map { "Select \($0.path) to reconnect it. Your Keep choices and cleanup history stay saved." }
+            ?? "Choose a folder to include in your scans. Nothing is selected for cleanup automatically."
+        if let root { panel.directoryURL = URL(fileURLWithPath: root.path, isDirectory: true) }
+        else if kind == "downloads" { panel.directoryURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first }
         beginSystemDialog()
         panel.begin { [weak self] result in
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 defer { self.endSystemDialog() }
-                guard result == .OK, let url = panel.url, let client = self.client else { return }
-                do {
-                    if url.path == self.homePath && !self.diskAccessConfigured { self.beginDiskAccessSetup(); return }
-                    let accessing = url.startAccessingSecurityScopedResource()
-                    let data = try url.bookmarkData(options: [.withSecurityScope], includingResourceValuesForKeys: nil, relativeTo: nil)
-                    try await self.removeUnconfirmedHomeGrant()
-                    let rootData = try await client.request(["action": "authorize", "path": url.path, "kind": url.path == self.homePath ? "home" : kind])
-                    let root = try EngineClient.decode(ScanRoot.self, rootData)
-                    self.bookmarks[root.path] = data
-                    do { try self.saveBookmarks() } catch { _ = try await client.request(["action": "forget", "id": root.id]); if accessing { url.stopAccessingSecurityScopedResource() }; throw error }
-                    self.accesses.append(url)
-                    await self.reload(); self.restartWatcher(); self.destination = .discover; self.refresh()
-                } catch { self.errorMessage = error.localizedDescription }
+                guard result == .OK, let url = panel.url, !self.busy, !self.hasCleanupWork else { return }
+                let path: String
+                do { path = try Self.physicalFolderPath(url) }
+                catch { self.errorMessage = error.localizedDescription; return }
+                if let root, path != root.path {
+                    self.errorMessage = "Select \(root.path) to reconnect it, or use Add folder to scan a different location."
+                    return
+                }
+                if path == self.homePath && !self.diskAccessConfigured { self.beginDiskAccessSetup(); return }
+                let existing = root ?? self.snapshot.roots.first { $0.path == path }
+                self.authorizeAndScan(path: path, kind: kind, reconnecting: existing, selectedURL: url)
             }
         }
     }
     private func saveBookmarks() throws { try JSONEncoder().encode(bookmarks).write(to: directory.appendingPathComponent("bookmarks.json"), options: .atomic) }
 
-    /// Preserve the system-supplied path; Rust validates each physical ancestor.
-    /// Foundation's path normalization can turn /private/var back into the /var link.
+    /// Pickers and bookmarks may spell /private/var as /var. Resolve that selected
+    /// location while its security scope is active, then let Rust validate every
+    /// physical ancestor and the grant identity. Keep the original URL for access.
+    static func physicalFolderPath(_ url: URL) throws -> String {
+        let accessing = url.startAccessingSecurityScopedResource()
+        defer { if accessing { url.stopAccessingSecurityScopedResource() } }
+        guard let physical = realpath(url.path, nil) else {
+            throw EngineError.message("This folder could not be opened. Choose an available folder and try again.")
+        }
+        defer { free(physical) }
+        return String(cString: physical)
+    }
+
     var homePath: String { scanHome.path }
     var homeAuthorized: Bool { snapshot.roots.contains { $0.path == homePath } }
 
+    func openScanLocations() {
+        showReview = false
+        showDuplicates = false
+        errorMessage = nil
+        settingsSection = "scan-locations"
+        destination = .settings
+        Task { await checkRootAccess() }
+    }
+
+    func reconnectRoot(_ root: ScanRoot) {
+        guard snapshot.roots.contains(root) else { return }
+        chooseFolder(kind: root.kind, reconnecting: root)
+    }
+
+    func checkRootAccess() async {
+        guard let client else { return }
+        rootAccessRequestID &+= 1
+        let requestID = rootAccessRequestID
+        let roots = snapshot.roots
+        do {
+            let response = try await client.request(["action": "root_access"])
+            let checks = try EngineClient.decode([RootAccessIssue].self, response)
+            guard roots == snapshot.roots, requestID >= appliedRootAccessRequestID else { return }
+            appliedRootAccessRequestID = requestID
+            let known = Set(roots.map(\.id))
+            bookmarkIssues = bookmarkIssues.filter { known.contains($0.key) }
+            let issues = checks.compactMap { check -> RootAccessIssue? in
+                guard known.contains(check.rootId) else { return nil }
+                return bookmarkIssues[check.rootId] ?? (check.needsAttention ? check : nil)
+            }
+            if rootAccessIssues != issues {
+                rootAccessIssues = issues
+                restartWatcher()
+            }
+            if let issue = issues.first {
+                let name = URL(fileURLWithPath: issue.path).lastPathComponent
+                let warning = "Scan access needs attention for \(name). Reconnect the folder in Scan locations."
+                rootAccessWarning = warning
+                errorMessage = warning
+            } else {
+                if let rootAccessWarning, errorMessage == rootAccessWarning { errorMessage = nil }
+                rootAccessWarning = nil
+            }
+            if issues.contains(where: { $0.path == homePath }) { invalidateStorageInventory() }
+        } catch {
+            guard roots == snapshot.roots, requestID >= appliedRootAccessRequestID else { return }
+            appliedRootAccessRequestID = requestID
+            if !bookmarkIssues.isEmpty { rootAccessIssues = Array(bookmarkIssues.values).sorted { $0.path < $1.path } }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func inventoryRoot(in snapshot: EngineSnapshot) -> ScanRoot? {
+        snapshot.roots.first { $0.path == homePath && $0.kind == "home" }
+    }
+
+    private func invalidateStorageInventory() {
+        inventoryGeneration &+= 1
+        storageInventory = nil
+        inventoryError = nil
+        inventoryLoading = false
+    }
+
+    func refreshStorageInventory() {
+        guard diskAccessConfigured, !busy, !showDiskAccess, !inventoryLoading, !hasCleanupWork,
+              let root = inventoryRoot(in: snapshot),
+              !rootAccessIssues.contains(where: { $0.rootId == root.id }), let client else { return }
+        inventoryGeneration &+= 1
+        let generation = inventoryGeneration
+        inventoryLoading = true
+        inventoryError = nil
+        Task {
+            defer { if inventoryGeneration == generation { inventoryLoading = false } }
+            do {
+                let report = try await readStorageInventory(client, root.id)
+                guard inventoryGeneration == generation, inventoryRoot(in: snapshot) == root,
+                      diskAccessConfigured, !rootAccessIssues.contains(where: { $0.rootId == root.id }) else { return }
+                storageInventory = report
+            } catch {
+                guard inventoryGeneration == generation, inventoryRoot(in: snapshot) == root,
+                      diskAccessConfigured, !rootAccessIssues.contains(where: { $0.rootId == root.id }) else { return }
+                inventoryError = error.localizedDescription
+            }
+        }
+    }
+
+    func openStorageProvider(_ provider: ManagedProviderID) {
+        managedProvider = provider
+        settingsSection = "managed-storage"
+        destination = .settings
+        // Provider tools have their own explicit review controls in Settings.
+        // Inventory findings never authorize a prune or a cleanup command.
+    }
+
     func scanMyMac() {
-        if diskAccessConfigured { authorizeAndScan(path: homePath, replaceContained: true) }
+        if diskAccessConfigured {
+            if let root = snapshot.roots.first(where: { $0.path == homePath }),
+               rootAccessIssues.contains(where: { $0.rootId == root.id }) {
+                reconnectRoot(root)
+            } else { authorizeAndScan(path: homePath, replaceContained: true) }
+        }
         else { beginDiskAccessSetup() }
     }
 
-    func beginDiskAccessSetup() {
-        guard client != nil, !busy, !snapshot.scanning, !snapshot.cleaning else { return }
-        if diskAccessPhase != .waiting {
+    func beginDiskAccessSetup(restart: Bool = false) {
+        guard client != nil, !busy, !snapshot.scanning, !hasCleanupWork else { return }
+        invalidateStorageInventory()
+        if restart || diskAccessPhase != .waiting {
             diskAccessRevision &+= 1
             diskAccessTask?.cancel()
             diskAccessPhase = .intro
@@ -1206,9 +1364,10 @@ struct DiscoveryPresentation: Equatable {
     /// This revokes only scan authorization; user files, Keep and history are untouched.
     private func removeUnconfirmedHomeGrant() async throws {
         guard !diskAccessConfigured, let root = snapshot.roots.first(where: { $0.path == homePath }), let client else { return }
+        invalidateStorageInventory()
         _ = try await client.request(["action": "forget", "id": root.id])
         bookmarks.removeValue(forKey: root.path)
-        accesses.filter { $0.path == root.path }.forEach { $0.stopAccessingSecurityScopedResource() }
+        accesses.filter { $0.path == root.path }.forEach { $0.url.stopAccessingSecurityScopedResource() }
         accesses.removeAll { $0.path == root.path }
     }
 
@@ -1238,6 +1397,7 @@ struct DiscoveryPresentation: Equatable {
         diskAccessMessage = "Checking folder access…"
         // A previous successful setup is no longer evidence once the user is
         // checking changed permissions. Failed or cancelled checks stay gated.
+        invalidateStorageInventory()
         diskAccessConfigured = false
         restartWatcher()
         diskAccessTask = Task { [weak self] in
@@ -1264,7 +1424,9 @@ struct DiscoveryPresentation: Equatable {
                 self.diskAccessPhase = .intro
                 self.diskAccessMessage = nil
                 self.finishDiskAccessSystemDialog()
-                self.authorizeAndScan(path: self.homePath, replaceContained: true)
+                let existing = self.snapshot.roots.first { $0.path == self.homePath }
+                let repair = existing.flatMap { root in self.rootAccessIssues.contains { $0.rootId == root.id } ? root : nil }
+                self.authorizeAndScan(path: self.homePath, replaceContained: true, reconnecting: repair)
             } catch {
                 guard self.diskAccessRevision == revision else { return }
                 self.diskAccessPhase = .waiting
@@ -1275,29 +1437,45 @@ struct DiscoveryPresentation: Equatable {
     }
 
     /// The pickerless half of `chooseFolder`. Same engine action, same bookmark, same watcher.
-    func authorizeAndScan(path: String, kind: String = "folder", replaceContained: Bool = false) {
-        guard path.hasPrefix("/"), !busy, !snapshot.scanning, !snapshot.cleaning, let client else { return }
-        let url = URL(fileURLWithPath: path, isDirectory: true)
-        let scanKind = url.path == homePath ? "home" : kind
-        guard !snapshot.roots.contains(where: { $0.path == url.path && $0.kind == scanKind }) else { restartWatcher(); destination = .discover; refresh(); return }
+    func authorizeAndScan(path: String, kind: String = "folder", replaceContained: Bool = false,
+                          reconnecting existing: ScanRoot? = nil, selectedURL: URL? = nil) {
+        guard path.hasPrefix("/"), !busy, !snapshot.scanning, !hasCleanupWork, let client else { return }
+        let physicalPath: String
+        do { physicalPath = try selectedURL.map(Self.physicalFolderPath) ?? path }
+        catch { errorMessage = error.localizedDescription; return }
+        let url = selectedURL ?? URL(fileURLWithPath: physicalPath, isDirectory: true)
+        let scanKind = physicalPath == homePath ? "home" : kind
+        guard existing != nil || !snapshot.roots.contains(where: { $0.path == physicalPath && $0.kind == scanKind }) else {
+            restartWatcher(); destination = .discover; refresh(); return
+        }
+        if let existing, existing.path != physicalPath || !snapshot.roots.contains(existing) {
+            errorMessage = "Select \(existing.path) to reconnect it, or use Add folder to scan a different location."
+            return
+        }
+        if physicalPath == homePath || (!diskAccessConfigured && homeAuthorized) { invalidateStorageInventory() }
         busy = true
         Task {
             var authorized = false
+            let accessing = selectedURL != nil && url.startAccessingSecurityScopedResource()
+            defer { if accessing && !authorized { url.stopAccessingSecurityScopedResource() } }
             do {
                 let data = try await Task.detached(priority: .utility) {
                     let scoped = try? url.bookmarkData(options: [.withSecurityScope], includingResourceValuesForKeys: nil, relativeTo: nil)
                     return try scoped ?? url.bookmarkData(includingResourceValuesForKeys: nil, relativeTo: nil)
                 }.value
                 let previousBookmarks = bookmarks
-                bookmarks[url.path] = data
+                bookmarks[physicalPath] = data
                 // A restart after the engine commits a broader root must already have
                 // its bookmark. Extra bookmarks from the old scopes are harmless.
                 do { try saveBookmarks() }
                 catch { bookmarks = previousBookmarks; throw error }
                 let root: ScanRoot
                 do {
-                    if url.path != homePath { try await removeUnconfirmedHomeGrant() }
-                    root = try EngineClient.decode(ScanRoot.self, await client.request(["action": "authorize", "path": url.path, "kind": scanKind, "replace_contained": replaceContained]))
+                    if physicalPath != homePath { try await removeUnconfirmedHomeGrant() }
+                    var request: [String: Any] = ["action": existing == nil ? "authorize" : "reauthorize",
+                        "path": physicalPath, "kind": scanKind, "replace_contained": replaceContained]
+                    if let existing { request["id"] = existing.id }
+                    root = try EngineClient.decode(ScanRoot.self, await client.request(request))
                 } catch {
                     bookmarks = previousBookmarks
                     try? saveBookmarks()
@@ -1308,16 +1486,19 @@ struct DiscoveryPresentation: Equatable {
                     let retained = Set(snapshot.roots.map(\.path))
                     func superseded(_ path: String) -> Bool { path.hasPrefix(root.path + "/") && !retained.contains(path) }
                     bookmarks = bookmarks.filter { !superseded($0.key) }
-                    accesses.filter { superseded($0.path) }.forEach { $0.stopAccessingSecurityScopedResource() }
+                    accesses.filter { superseded($0.path) }.forEach { $0.url.stopAccessingSecurityScopedResource() }
                     accesses.removeAll { superseded($0.path) }
                     // The broader bookmark is already durable if pruning fails.
                     do { try saveBookmarks() } catch { errorMessage = error.localizedDescription }
                 }
-                await reload(); restartWatcher(); destination = .discover; authorized = true
+                if let existing { bookmarkIssues.removeValue(forKey: existing.id) }
+                if accessing { accesses.append((physicalPath, url)) }
+                errorMessage = nil
+                await reload(); await checkRootAccess(); restartWatcher(); destination = .discover; authorized = true
             } catch {
                 // A failed Home upgrade can leave the older folder policy in
                 // place. Do not let its watcher resume after confirmation.
-                if url.path == homePath { diskAccessConfigured = false }
+                if physicalPath == homePath { diskAccessConfigured = false }
                 errorMessage = error.localizedDescription
                 await reload(); restartWatcher()
             }
@@ -1364,6 +1545,8 @@ struct DiscoveryPresentation: Equatable {
     func refresh() {
         guard !busy, !discoveryPresentation.isRequestPending, let client else { return }
         if homeAuthorized && !diskAccessConfigured { beginDiskAccessSetup(); return }
+        if !rootAccessIssues.isEmpty { openScanLocations(); return }
+        refreshStorageInventory()
         discoveryPresentation.beginRequestedScan()
         Task {
             var accepted = false
@@ -1769,15 +1952,19 @@ struct DiscoveryPresentation: Equatable {
         }
     }
     func forgetRoot(_ root: ScanRoot) {
-        guard !busy, !snapshot.scanning else { return }
+        guard !busy, !snapshot.scanning, !hasCleanupWork else { return }
+        if root.path == homePath { invalidateStorageInventory() }
+        busy = true
         Task {
+            defer { busy = false }
             do {
                 _ = try await client?.request(["action": "forget", "id": root.id])
                 bookmarks.removeValue(forKey: root.path); try saveBookmarks()
-                accesses.filter { $0.path == root.path }.forEach { $0.stopAccessingSecurityScopedResource() }
+                accesses.filter { $0.path == root.path }.forEach { $0.url.stopAccessingSecurityScopedResource() }
                 accesses.removeAll { $0.path == root.path }
-                await reload(); restartWatcher()
+                bookmarkIssues.removeValue(forKey: root.id)
             } catch { errorMessage = error.localizedDescription }
+            await reload(); await checkRootAccess(); restartWatcher()
         }
     }
     private func perform(_ request: [String: Any]) {

--- a/native/Chippytea/ManagedStorageView.swift
+++ b/native/Chippytea/ManagedStorageView.swift
@@ -186,6 +186,11 @@ struct ManagedStorageView: View {
                 ManagedProviderResult(review: review)
             }
         }
+        .onAppear { selectedProvider = model.managedProvider }
+        .onChange(of: model.managedProvider) { _, provider in
+            guard loadingProvider == nil, cancellingProvider == nil else { return }
+            selectedProvider = provider
+        }
         .onChange(of: selectedProvider) { _, _ in
             guard loadingProvider == nil, cancellingProvider == nil else { return }
             review = nil

--- a/native/Chippytea/Models.swift
+++ b/native/Chippytea/Models.swift
@@ -50,6 +50,15 @@ struct ScanRoot: Codable, Identifiable, Equatable {
     var name: String { URL(fileURLWithPath: path).lastPathComponent }
 }
 
+struct RootAccessIssue: Decodable, Identifiable, Equatable {
+    let rootId: String
+    let path: String
+    let status: String
+    let message: String?
+    var id: String { rootId }
+    var needsAttention: Bool { status != "available" }
+}
+
 struct Candidate: Codable, Identifiable, Hashable {
     var id: String
     var rootId: String
@@ -73,13 +82,13 @@ struct Candidate: Codable, Identifiable, Hashable {
     var recommended: Bool { suggestionEligible == true && canReviewCleanup }
     var isDeveloper: Bool {
         switch kind {
-        case "node", "cargo", "venv", "webcache", "xcode", "swiftpm", "dotnet", "gradle", "dart", "flutter", "zig": return true
+        case "node", "cargo", "venv", "webcache", "devcache", "pythoncache", "xcode", "swiftpm", "dotnet", "gradle", "dart", "flutter", "zig": return true
         default: return false
         }
     }
     var isCacheOrLog: Bool {
         switch kind {
-        case "cache", "log", "crashreport": return true
+        case "devcache", "cache", "log", "crashreport": return true
         default: return false
         }
     }
@@ -94,13 +103,20 @@ struct Candidate: Codable, Identifiable, Hashable {
         return isDeveloper || isCacheOrLog || isPersonalFile
             ? nil : "This item type is not supported by this version of chippytea."
     }
+    /// Early activity exclusions deliberately skip cache traversal. An unknown
+    /// allocation must not be presented as an empty cache or recoverable space.
+    var measuredAllocatedBytes: UInt64? {
+        if kind == "devcache", blockedReason != nil, fingerprint.isEmpty,
+           fileCount == 0, allocatedBytes == 0 { return nil }
+        return allocatedBytes
+    }
     var canReviewCleanup: Bool { cleanupBlockedReason == nil }
     /// A category is not permission to delete: only the existing verified
     /// developer kinds can opt into permanent cleanup. New kinds fail closed.
     var canDeletePermanently: Bool {
         guard canReviewCleanup, eligiblePermanent else { return false }
         switch kind {
-        case "node", "cargo", "venv", "webcache": return true
+        case "node", "cargo", "venv", "webcache", "devcache": return true
         default: return false
         }
     }
@@ -110,6 +126,8 @@ struct Candidate: Codable, Identifiable, Hashable {
         case "cargo": return "hammer"
         case "venv": return "terminal"
         case "webcache": return "arrow.triangle.2.circlepath"
+        case "devcache": return "arrow.triangle.2.circlepath"
+        case "pythoncache": return "terminal"
         case "cache": return "externaldrive"
         case "log": return "doc.text"
         case "crashreport": return "exclamationmark.bubble"
@@ -129,6 +147,8 @@ struct Candidate: Codable, Identifiable, Hashable {
         case "cargo": return "Build artifacts"
         case "venv": return "Python environment"
         case "webcache": return "Build cache"
+        case "devcache": return "Developer cache"
+        case "pythoncache": return "Python bytecode cache"
         case "cache": return "App cache"
         case "log": return "App log"
         case "crashreport": return "Crash report"
@@ -153,7 +173,8 @@ struct Candidate: Codable, Identifiable, Hashable {
         let name = location.lastPathComponent
         guard !name.isEmpty else { return title }
         switch kind {
-        case "node", "cargo", "venv", "webcache", "swiftpm", "dotnet", "gradle", "dart", "flutter", "zig":
+        case "devcache": return title
+        case "node", "cargo", "venv", "webcache", "pythoncache", "swiftpm", "dotnet", "gradle", "dart", "flutter", "zig":
             let parent = (location.deletingLastPathComponent as NSString).lastPathComponent
             return parent.isEmpty || parent == "/" ? name : "\(parent) / \(name)"
         default:

--- a/native/Chippytea/SelfTest.swift
+++ b/native/Chippytea/SelfTest.swift
@@ -2,10 +2,28 @@ import Foundation
 import Combine
 import CoreServices
 import SQLite3
+import SwiftUI
 
 enum NativeSelfTest {
     @MainActor static func runAccessFlow() async {
         do {
+            if CommandLine.arguments.contains("--access-preview") {
+                try await accessPreview()
+                return
+            }
+            if CommandLine.arguments.contains("--developer-cache-regression") {
+                try await developerCachePresentation()
+                try storageInventoryDecoding()
+                print("PASS native developer caches: unified findings, sorting, filters, mixed selection and permanent review")
+                exit(0)
+            }
+            if CommandLine.arguments.contains("--access-recovery-regression") {
+                try storageInventoryDecoding()
+                try await folderAccessRecovery()
+                try await inventoryPublication()
+                print("PASS native access recovery regressions")
+                exit(0)
+            }
             if CommandLine.arguments.contains("--state-directory-regression") {
                 try stateDirectoryMigration()
                 print("PASS native state-directory migration and interrupted recovery")
@@ -40,6 +58,10 @@ enum NativeSelfTest {
                 exit(0)
             }
             try stateDirectoryMigration()
+            try await developerCachePresentation()
+            try storageInventoryDecoding()
+            try await folderAccessRecovery()
+            try await inventoryPublication()
             try await accessFlow()
             try await foregroundSummarySurvivesRestart()
             try await forgottenRootInvalidatesScanPresentation()
@@ -57,6 +79,372 @@ enum NativeSelfTest {
             exit(0)
         }
         catch { fputs("FAIL native access flow: \(error)\n", stderr); exit(1) }
+    }
+
+    @MainActor private static var previewWindow: NSWindow?
+
+    /// A visible fixture uses the real model, scan pipeline and views while
+    /// keeping permissions, observations and cleanup inside disposable data.
+    @MainActor private static func accessPreview() async throws {
+        if CommandLine.arguments.contains("--dark") { NSApp.appearance = NSAppearance(named: .darkAqua) }
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("chippytea-access-preview-\(UUID().uuidString)")
+        try fm.createDirectory(at: base, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        guard let physical = realpath(base.path, nil) else { throw EngineError.message("Cannot resolve preview fixture") }
+        let directory = URL(fileURLWithPath: String(cString: physical)); free(physical)
+        let home = directory.appendingPathComponent("Example Mac")
+        let state = directory.appendingPathComponent("State")
+        try fm.createDirectory(at: home, withIntermediateDirectories: false)
+        try fm.createDirectory(at: state, withIntermediateDirectories: false)
+        for (relative, count) in [(".npm/_cacache/example-package", 2_000_000),
+                                  (".cache/uv/example-package", 3_000_000),
+                                  (".rustup/toolchains/example-toolchain/lib", 4_000_000),
+                                  ("Library/Logs/example.log", 8_192)] {
+            let file = home.appendingPathComponent(relative)
+            try fm.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data(repeating: 65, count: count).write(to: file)
+            try fm.setAttributes([.modificationDate: Date().addingTimeInterval(-10 * 86_400)], ofItemAtPath: file.path)
+        }
+        guard let identity = DiskAccessAppIdentity.current() else { throw EngineError.message("Missing preview identity") }
+        try JSONEncoder().encode(identity).write(to: state.appendingPathComponent("disk-access-app.json"))
+        try JSONEncoder().encode("completed").write(to: state.appendingPathComponent("disk-access.json"))
+        let model = AppModel(directory: state, scanHome: home)
+        await model.start()
+        model.authorizeAndScan(path: home.path, kind: "home", replaceContained: true)
+        let deadline = Date().addingTimeInterval(15)
+        while model.busy || model.discoveryPresentation.isRequestPending || model.snapshot.scanning
+                || model.inventoryLoading || model.storageInventory == nil {
+            try require(Date() < deadline, "Preview scan did not complete: \(model.errorMessage ?? model.inventoryError ?? "no error")")
+            try await Task.sleep(for: .milliseconds(40))
+        }
+        model.destination = .discover
+        model.panelVisible = true
+        model.reduceMotion = true
+        let updates = UpdateController(model: model, enabled: false)
+        let view = NSHostingView(rootView: RootView(model: model, updates: updates))
+        let window = NSWindow(contentRect: NSRect(x: 150, y: 180, width: TeaTheme.panelWidth, height: model.panelHeight),
+                              styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        window.title = "Chippytea Preview · disposable files"
+        window.contentView = view
+        window.isReleasedWhenClosed = false
+        previewWindow = window
+        NSApp.setActivationPolicy(.regular)
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        print("Native preview ready: \(model.storageInventory?.rows.count ?? 0) measured locations; fixture \(home.path)")
+    }
+
+    @MainActor private static func developerCachePresentation() async throws {
+        let identity = EngineIdentity(device: 1, inode: 2, mode: 0o040755, size: 0, modifiedNs: 0, changedNs: 0)
+        let root = ScanRoot(id: "home", path: "/fixture", kind: "home", identity: identity)
+        let cache = Candidate(id: "npm-cache", rootId: root.id, path: "/fixture/.npm/_cacache",
+            title: "npm cache", kind: "devcache", logicalBytes: 500_000_000, allocatedBytes: 500_000_000,
+            fileCount: 1, modifiedNs: 30, explanation: "Verified disposable cache",
+            consequence: "npm will download packages again", eligiblePermanent: true, blockedReason: nil,
+            identity: identity, fingerprint: "contents", evidence: "ownership", suggestionEligible: true)
+        var presentationFixture = cache
+        presentationFixture.kind = "node"
+        try candidatePresentation(presentationFixture)
+        try require(cache.canDeletePermanently && cache.isDeveloper && cache.isCacheOrLog && cache.recommended,
+                    "Verified developer caches must be actionable in both Developer and Caches & logs")
+        var build = cache
+        build.id = "build"; build.kind = "cargo"; build.path = "/fixture/project/target"; build.title = "Build artifacts"
+        build.allocatedBytes = 100_000_000; build.modifiedNs = 20
+        var log = cache
+        log.id = "log"; log.kind = "log"; log.path = "/fixture/Library/Logs/example.log"
+        log.title = "example.log"; log.eligiblePermanent = false
+        log.allocatedBytes = 8_192; log.modifiedNs = 10
+        let toolchain = StorageInventoryReportDTO.Row(id: cache.id, title: "Rust toolchains", category: "Developer tools",
+            path: "/fixture/.rustup/toolchains", state: .complete, allocatedBytes: 300_000_000, logicalBytes: 300_000_000,
+            files: 1, directories: 1, detail: "Installed compilers", ownerFollowup: "Review installed toolchains",
+            provider: nil, cleanupAuthority: .reviewOnly)
+        let duplicate = StorageInventoryReportDTO.Row(id: "old-cache-observation", title: "npm package cache", category: "Developer tools",
+            path: "/fixture/.npm", state: .complete, allocatedBytes: 500_000_000, logicalBytes: 500_000_000,
+            files: 1, directories: 1, detail: "Legacy observation", ownerFollowup: "Review", provider: nil, cleanupAuthority: .reviewOnly)
+        let inventory = StorageInventoryReportDTO(rows: [toolchain, duplicate], issues: [], omittedIssues: 0,
+            examinedEntries: 4, elapsedMs: 1, complete: true)
+        func findings(_ filter: DiscoveryFilter = .all, _ query: String = "", _ sort: DiscoverySort = .suggested) -> [DiscoveryFinding] {
+            DiscoveryFinding.list(candidates: [cache, build, log], inventory: inventory, filter: filter, query: query, sort: sort)
+        }
+        try require(findings().map(\.id) == ["candidate:npm-cache", "candidate:build", "candidate:log", "managed:npm-cache"],
+                    "Unified findings must retain engine order, distinct identities and no duplicate aggregate cache row")
+        try require(findings(.all, "", .largest).map(\.path) == [cache.path, toolchain.path, build.path, log.path],
+                    "Largest first must interleave actionable caches and installed tool data in one list")
+        try require(findings(.all, "", .oldest).map(\.path) == [log.path, build.path, cache.path, toolchain.path],
+                    "Unknown modification times must follow known times")
+        try require(findings(.all, "", .name).map(\.path) == [log.path, cache.path, build.path, toolchain.path],
+                    "Name sorting must use the visible developer cache title")
+        try require(findings(.caches).map(\.path) == [cache.path, log.path]
+                    && findings(.developer).map(\.path) == [cache.path, build.path, toolchain.path]
+                    && findings(.personal).isEmpty && findings(.all, "npm").map(\.path) == [cache.path]
+                    && findings(.all, "package cache").isEmpty,
+                    "Unified search and filters must show real cache actions without reviving duplicate observations")
+        var unverified = cache
+        unverified.eligiblePermanent = false
+        try require(!unverified.canDeletePermanently, "A cache name alone cannot authorize permanent cleanup")
+        unverified.eligiblePermanent = true; unverified.blockedReason = "npm is running"
+        try require(!unverified.canReviewCleanup && !unverified.canDeletePermanently,
+                    "In-use caches must remain blocked in the native list")
+
+        unverified.allocatedBytes = 0; unverified.fileCount = 0; unverified.fingerprint = ""
+        try require(unverified.measuredAllocatedBytes == nil && DiscoveryFinding.candidate(unverified).allocatedBytes == nil,
+                    "An early blocked cache must show an unknown size rather than zero bytes")
+        let mixed = DiscoveryFinding.list(candidates: [unverified, build], inventory: nil, filter: .all, query: "", sort: .largest)
+        try require(mixed.map(\.path) == [build.path, unverified.path], "Unmeasured caches sort after measured findings")
+
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("chippytea-cache-presentation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let model = AppModel(directory: directory)
+        await model.start()
+        model.snapshot = EngineSnapshot(roots: [root], candidates: [cache, build, log])
+        model.selection = [cache.id, build.id]
+        model.reviewSelection()
+        try require(model.showReview && model.reviewItems == [cache, build]
+                    && model.reviewItems.allSatisfy(\.canDeletePermanently)
+                    && CleanupPreview(items: model.reviewItems, wallet: Wallet(), permanently: true).estimatedCoins > 0,
+                    "Developer cache and build folder must share the same selection and permanent review")
+        model.selection.insert(log.id)
+        model.reviewSelection()
+        try require(model.reviewItems == [cache, build, log] && model.reviewItems.allSatisfy(\.canReviewCleanup)
+                    && !model.reviewItems.allSatisfy(\.canDeletePermanently),
+                    "A mixed cache/log selection must use the existing Trash-only review")
+        try require(model.snapshot.wallet == Wallet() && model.snapshot.history.isEmpty,
+                    "List rendering and review must never perform cleanup or grant credit")
+    }
+
+    private static func storageInventoryDecoding() throws {
+        let row: [String: Any] = ["id": "rust-toolchains", "title": "Rust toolchains", "category": "Developer tools",
+            "path": "/fixture/.rustup/toolchains", "state": "Complete", "allocated_bytes": 4096, "logical_bytes": 123,
+            "files": 1, "directories": 1, "detail": "Fixture", "owner_followup": "Review installed toolchains",
+            "cleanup_authority": "ReviewOnly"]
+        func data(_ rows: [[String: Any]]) throws -> Data {
+            try JSONSerialization.data(withJSONObject: ["rows": rows, "issues": [], "omitted_issues": 0,
+                "examined_entries": 2, "elapsed_ms": 1, "complete": true])
+        }
+        let report = try StorageInventoryReportDTO.decode(data([row]))
+        let item = report.rows[0]
+        try require(item.matches(filter: .developer, query: "rust") && !item.matches(filter: .caches, query: "")
+                    && !item.matches(filter: .personal, query: "") && !item.matches(filter: .all, query: "absent"),
+                    "Inventory must participate in the visible category filters and search")
+        var dangerous = row; dangerous["cleanup_authority"] = "Permanent"
+        var rejected = false
+        do { _ = try StorageInventoryReportDTO.decode(data([dangerous])) } catch { rejected = true }
+        try require(rejected, "Inventory responses must reject cleanup authority")
+        rejected = false
+        do { _ = try StorageInventoryReportDTO.decode(data([row, row])) } catch { rejected = true }
+        try require(rejected, "Inventory responses must reject duplicate row identities")
+    }
+
+    @MainActor private static func folderAccessRecovery() async throws {
+        for scenario in ["replacement", "permissions", "legacy-home", "forget-warning", "forget-unrelated-error"] {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("chippytea-access-recovery-\(UUID().uuidString)")
+        try fm.createDirectory(at: base, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        guard let physical = realpath(base.path, nil) else { throw EngineError.message("Cannot resolve recovery fixture") }
+        let directory = URL(fileURLWithPath: String(cString: physical)); free(physical)
+        let folder = directory.appendingPathComponent("Projects")
+        let state = directory.appendingPathComponent("State")
+        try fm.createDirectory(at: folder, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o755])
+        try fm.createDirectory(at: state, withIntermediateDirectories: false)
+        let sentinel = Data("Preserve both versions of the disposable folder".utf8)
+        try sentinel.write(to: folder.appendingPathComponent("original.txt"))
+        var initial: EngineClient? = try EngineClient(database: state.appendingPathComponent("library.sqlite"))
+        let root = try EngineClient.decode(ScanRoot.self,
+            await initial!.request(["action": "authorize", "path": folder.path,
+                                    "kind": scenario == "legacy-home" ? "folder" : "projects"]))
+        let bookmark = try folder.bookmarkData(includingResourceValuesForKeys: nil, relativeTo: nil)
+        try JSONEncoder().encode([folder.path: bookmark]).write(to: state.appendingPathComponent("bookmarks.json"))
+        if scenario == "legacy-home" {
+            try JSONEncoder().encode("completed").write(to: state.appendingPathComponent("disk-access.json"))
+            guard let identity = DiskAccessAppIdentity.current() else { throw EngineError.message("Missing test app identity") }
+            try JSONEncoder().encode(identity).write(to: state.appendingPathComponent("disk-access-app.json"))
+        }
+        initial = nil
+        let original = scenario == "permissions" ? folder : directory.appendingPathComponent("Original")
+        if scenario != "permissions" {
+            try fm.moveItem(at: folder, to: original)
+            try fm.createDirectory(at: folder, withIntermediateDirectories: false)
+        }
+        try sentinel.write(to: folder.appendingPathComponent("replacement.txt"))
+        if scenario == "permissions" { try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: folder.path) }
+        let model = AppModel(directory: state, scanHome: scenario == "legacy-home" ? folder : directory.appendingPathComponent("UnusedHome"))
+        await model.start()
+        try require(model.snapshot.roots.map(\.id) == [root.id] && model.rootAccessIssues.map(\.rootId) == [root.id],
+                    "A replaced folder must stay visible with an actionable access issue")
+        try require(!model.snapshot.scanning, "A broken saved grant must not resume background scanning")
+        if scenario.hasPrefix("forget-") {
+            let unrelated = "An unrelated fixture operation failed"
+            if scenario == "forget-unrelated-error" { model.errorMessage = unrelated }
+            model.forgetRoot(root)
+            let deadline = Date().addingTimeInterval(10)
+            while model.busy || !model.snapshot.roots.isEmpty {
+                try require(Date() < deadline, "The broken folder was not forgotten")
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            try require(model.rootAccessIssues.isEmpty
+                        && model.errorMessage == (scenario == "forget-unrelated-error" ? unrelated : nil),
+                        "Forgetting the last broken folder must clear its warning and preserve unrelated errors")
+            try require(try Data(contentsOf: original.appendingPathComponent("original.txt")) == sentinel
+                        && Data(contentsOf: folder.appendingPathComponent("replacement.txt")) == sentinel,
+                        "Forgetting access must preserve both physical folders")
+            continue
+        }
+        model.openScanLocations()
+        try require(model.destination == .settings && model.settingsSection == "scan-locations",
+                    "Access recovery must open the scan-location controls")
+        if scenario == "replacement" {
+            model.authorizeAndScan(path: folder.path, kind: root.kind, reconnecting: root, selectedURL: original)
+            try require(!model.busy && model.snapshot.roots == [root] && model.errorMessage?.hasPrefix("Select ") == true,
+                        "Reconnection must reject a genuinely different selected folder")
+        }
+        let pickerPath = folder.path.hasPrefix("/private/var/") ? String(folder.path.dropFirst("/private".count)) : folder.path
+        let pickerURL = URL(fileURLWithPath: pickerPath, isDirectory: true)
+        try require(try AppModel.physicalFolderPath(pickerURL) == folder.path,
+                    "Picker aliases must resolve to the exact saved physical folder")
+        model.authorizeAndScan(path: pickerPath, kind: root.kind, reconnecting: root, selectedURL: pickerURL)
+        let deadline = Date().addingTimeInterval(10)
+        while model.busy || model.snapshot.scanning || model.snapshot.roots.first == root
+                || model.discoveryPresentation.isRequestPending || model.discoveryPresentation.isForeground {
+            try require(Date() < deadline, "Reconnected folder did not finish scanning: \(model.errorMessage ?? "no error")")
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        try require(model.rootAccessIssues.isEmpty && model.snapshot.roots.count == 1,
+                    "Reconnection must replace the old grant and clear its access issue")
+        try require(model.snapshot.history.isEmpty && model.snapshot.wallet.pendingCoins == 0,
+                    "Reconnection cannot create cleanup history or chips")
+        try require(try Data(contentsOf: original.appendingPathComponent("original.txt")) == sentinel
+                    && Data(contentsOf: folder.appendingPathComponent("replacement.txt")) == sentinel,
+                    "Reconnection must preserve the old and replacement folder contents")
+        model.diskAccessPhase = .waiting
+        model.diskAccessStep = .enable
+        model.beginDiskAccessSetup(restart: true)
+        try require(model.showDiskAccess && model.diskAccessStep == .permission && model.diskAccessPhase == .intro,
+                    "Redo setup must return to the first step even after a previous waiting state")
+        model.dismissDiskAccess()
+        print("PASS native folder access recovery (\(scenario)): visible failed grant, explicit reconnect, preserved files and redo setup")
+        }
+    }
+
+    @MainActor private final class InventoryReadFixture {
+        var calls = 0
+        var returned = Set<Int>()
+        var held: [Int: CheckedContinuation<StorageInventoryReportDTO, Error>] = [:]
+
+        func read() async throws -> StorageInventoryReportDTO {
+            calls += 1
+            let call = calls
+            defer { returned.insert(call) }
+            return try await withCheckedThrowingContinuation { held[call] = $0 }
+        }
+
+        func finish(_ call: Int, with result: Result<StorageInventoryReportDTO, Error>) throws {
+            guard let continuation = held.removeValue(forKey: call) else {
+                throw EngineError.message("No matching disposable inventory read")
+            }
+            continuation.resume(with: result)
+        }
+
+        func release() {
+            let outstanding = held
+            held.removeAll()
+            for continuation in outstanding.values {
+                continuation.resume(throwing: EngineError.message("Disposable inventory fixture finished"))
+            }
+        }
+    }
+
+    @MainActor private static func inventoryPublication() async throws {
+        let fm = FileManager.default
+        func until(_ message: String, _ ready: () -> Bool) async throws {
+            let deadline = Date().addingTimeInterval(10)
+            while !ready() {
+                try require(Date() < deadline, message)
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        func report(_ entries: Int) throws -> StorageInventoryReportDTO {
+            try StorageInventoryReportDTO.decode(JSONSerialization.data(withJSONObject: [
+                "rows": [], "issues": [], "omitted_issues": 0,
+                "examined_entries": entries, "elapsed_ms": 1, "complete": true,
+            ]))
+        }
+        for scenario in ["forget-success", "forget-error", "reconnect-success", "reconnect-error", "redo-success", "redo-error", "snapshot-loss"] {
+            let base = fm.temporaryDirectory.appendingPathComponent("chippytea-inventory-publication-\(UUID().uuidString)")
+            try fm.createDirectory(at: base, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+            let directory = URL(fileURLWithPath: try AppModel.physicalFolderPath(base), isDirectory: true)
+            let home = directory.appendingPathComponent("Home")
+            let state = directory.appendingPathComponent("State")
+            try fm.createDirectory(at: home, withIntermediateDirectories: false)
+            try fm.createDirectory(at: state, withIntermediateDirectories: false)
+            var initial: EngineClient? = try EngineClient(database: state.appendingPathComponent("library.sqlite"))
+            let root = try EngineClient.decode(ScanRoot.self, await initial!.request(["action": "authorize", "path": home.path, "kind": "home"]))
+            initial = nil
+            let bookmark = try home.bookmarkData(includingResourceValuesForKeys: nil, relativeTo: nil)
+            try JSONEncoder().encode([home.path: bookmark]).write(to: state.appendingPathComponent("bookmarks.json"))
+            try JSONEncoder().encode("completed").write(to: state.appendingPathComponent("disk-access.json"))
+            guard let identity = DiskAccessAppIdentity.current() else { throw EngineError.message("Missing inventory test app identity") }
+            try JSONEncoder().encode(identity).write(to: state.appendingPathComponent("disk-access-app.json"))
+            let inventory = InventoryReadFixture()
+            let reads = SnapshotReadFixture()
+            defer { inventory.release(); reads.release() }
+            let model = AppModel(directory: state, scanHome: home,
+                                 readStorageInventory: { _, _ in try await inventory.read() },
+                                 readSnapshot: { try await reads.read($0) })
+            await model.start()
+            try await until("The initial inventory or scan did not start and settle") {
+                inventory.held[1] != nil && !model.busy && !model.snapshot.scanning
+                    && !model.discoveryPresentation.isRequestPending && !model.discoveryPresentation.isForeground
+            }
+            if scenario == "snapshot-loss" {
+                try inventory.finish(1, with: .success(report(1)))
+                try await until("The initial inventory did not publish") { model.storageInventory != nil && !model.inventoryLoading }
+                _ = try await model.client!.request(["action": "forget", "id": root.id])
+                await model.reload()
+                try require(model.storageInventory == nil && !model.inventoryLoading && model.inventoryError == nil,
+                            "Applying a snapshot without Home must clear its published inventory")
+                continue
+            }
+            if scenario.hasPrefix("forget-") {
+                reads.holdCount = 1
+                model.forgetRoot(root)
+                try await until("The post-forget snapshot was not held") { !reads.held.isEmpty }
+                try require(model.snapshot.roots == [root] && model.storageInventory == nil && !model.inventoryLoading,
+                            "Forgetting must invalidate inventory before its new snapshot arrives")
+                model.refreshStorageInventory()
+                try require(inventory.calls == 1, "An old visible Home grant cannot start inventory while forgetting")
+            } else if scenario.hasPrefix("reconnect-") {
+                model.authorizeAndScan(path: home.path, kind: "home", reconnecting: root, selectedURL: home)
+                try require(!model.inventoryLoading && model.storageInventory == nil,
+                            "Same-identity reconnection must invalidate the previous inventory immediately")
+                try await until("Reconnection did not start fresh inventory") { inventory.held[2] != nil }
+            } else {
+                model.beginDiskAccessSetup(restart: true)
+                try require(!model.inventoryLoading && model.storageInventory == nil,
+                            "Redoing access setup must invalidate pending inventory")
+                model.refreshStorageInventory()
+                try require(inventory.calls == 1, "Inventory must stay paused while access setup is open")
+                model.dismissDiskAccess()
+                model.refreshStorageInventory()
+                try await until("Inventory did not resume after leaving setup") { inventory.held[2] != nil }
+            }
+            let oldResponse: Result<StorageInventoryReportDTO, Error> = scenario.hasSuffix("error")
+                ? .failure(EngineError.message("Stale inventory failure")) : .success(try report(1))
+            try inventory.finish(1, with: oldResponse)
+            try await until("The stale inventory response did not resume") { inventory.returned.contains(1) }
+            await Task.yield()
+            try require(model.storageInventory == nil && model.inventoryError == nil,
+                        "A stale inventory success or failure cannot publish after access changes")
+            if scenario.hasPrefix("forget-") {
+                guard let call = reads.held.keys.first else { throw EngineError.message("Missing held forget snapshot") }
+                try reads.finish(call, with: .success(try await model.client!.snapshot()))
+                try await until("Forgetting did not complete after releasing its snapshot") { !model.busy && model.snapshot.roots.isEmpty }
+            } else {
+                try require(model.inventoryLoading, "An older response cannot clear a newer inventory request's loading state")
+                try inventory.finish(2, with: .success(report(2)))
+                try await until("The current inventory did not publish") { model.storageInventory?.examinedEntries == 2 && !model.inventoryLoading }
+            }
+        }
+        print("PASS native inventory publication: late success/error rejected, current loading retained, forgotten Home cleared, same-identity reconnect and redo setup isolated")
     }
 
     @MainActor private static func stateDirectoryMigration() throws {
@@ -849,6 +1237,7 @@ enum NativeSelfTest {
             ("node", "/Projects/Plum/node_modules", "Plum dependencies", "Plum / node_modules"),
             ("cargo", "/Projects/service/target", "service build artifacts", "service / target"),
             ("venv", "/Projects/api/.venv", "api Python environment", "api / .venv"),
+            ("devcache", "/Users/test/.npm/_cacache", "npm cache", "npm cache"),
             ("cache", "/Library/Caches/com.example.Editor", "com.example.Editor cache", "com.example.Editor"),
             ("xcode", "/Library/Developer/Xcode/DerivedData/App-abc123", "App-abc123 Xcode data", "App-abc123"),
             ("archive", "/Downloads/Archive.zip", "Archive.zip", "Archive.zip"),
@@ -876,6 +1265,7 @@ enum NativeSelfTest {
         let categories: [(String, String, DiscoveryFilter, Bool)] = [
             ("node", "Dependencies", .developer, true), ("cargo", "Build artifacts", .developer, true),
             ("venv", "Python environment", .developer, true), ("webcache", "Build cache", .developer, true),
+            ("pythoncache", "Python bytecode cache", .developer, false),
             ("xcode", "Xcode build data", .developer, false), ("cache", "App cache", .caches, false),
             ("log", "App log", .caches, false), ("crashreport", "Crash report", .caches, false),
             ("installer", "Installer", .personal, false), ("archive", "Archive", .personal, false),

--- a/native/Chippytea/StorageSuggestionsView.swift
+++ b/native/Chippytea/StorageSuggestionsView.swift
@@ -1,0 +1,311 @@
+import Foundation
+import SwiftUI
+
+/// Automatic filesystem observations stay outside CandidateDTO and cleanup.
+/// Unknown authority or state values fail decoding rather than becoming actions.
+struct StorageInventoryReportDTO: Decodable {
+    enum State: String, Decodable {
+        case complete = "Complete"
+        case partial = "Partial"
+        case unavailable = "Unavailable"
+    }
+
+    enum CleanupAuthority: String, Decodable {
+        case reviewOnly = "ReviewOnly"
+    }
+
+    enum IssueKind: String, Decodable {
+        case permissionDenied = "PermissionDenied"
+        case symlink = "Symlink"
+        case changed = "Changed"
+        case depthLimit = "DepthLimit"
+        case entryLimit = "EntryLimit"
+        case timeLimit = "TimeLimit"
+        case cloudPlaceholder = "CloudPlaceholder"
+        case mountBoundary = "MountBoundary"
+        case unavailable = "Unavailable"
+    }
+
+    struct Row: Decodable, Identifiable {
+        let id: String
+        let title: String
+        let category: String
+        let path: String
+        let state: State
+        let allocatedBytes: UInt64?
+        let logicalBytes: UInt64?
+        let files: UInt64
+        let directories: UInt64
+        let detail: String
+        let ownerFollowup: String
+        let provider: String?
+        let cleanupAuthority: CleanupAuthority
+
+        var owner: ManagedProviderID? {
+            guard let provider else { return nil }
+            return ManagedProviderID(rawValue: provider)
+        }
+
+        var sizeLabel: String {
+            guard let allocatedBytes else { return "Size unavailable" }
+            let size = space(allocatedBytes)
+            return state == .partial ? size + " measured" : size
+        }
+
+        func matches(filter: DiscoveryFilter, query: String) -> Bool {
+            let categoryMatches: Bool
+            switch filter {
+            case .all: categoryMatches = true
+            case .developer: categoryMatches = category == "Developer tools" || category == "Containers"
+            case .caches:
+                categoryMatches = ["cache", "logs", "reports"].contains { title.localizedCaseInsensitiveContains($0) }
+            case .personal: categoryMatches = false
+            }
+            return categoryMatches && (query.isEmpty || title.localizedCaseInsensitiveContains(query)
+                || path.localizedCaseInsensitiveContains(query) || category.localizedCaseInsensitiveContains(query))
+        }
+    }
+
+    struct Issue: Decodable {
+        let path: String
+        let kind: IssueKind
+        let detail: String
+    }
+
+    let rows: [Row]
+    let issues: [Issue]
+    let omittedIssues: UInt64
+    let examinedEntries: UInt64
+    let elapsedMs: UInt64
+    let complete: Bool
+
+    static func decode(_ data: Data) throws -> Self {
+        let report = try EngineClient.decode(Self.self, data)
+        guard report.rows.count <= 64, report.issues.count <= 64,
+              Set(report.rows.map(\.id)).count == report.rows.count,
+              !report.complete || (report.issues.isEmpty && report.omittedIssues == 0),
+              report.rows.allSatisfy({ row in
+                  row.cleanupAuthority == .reviewOnly && row.path.hasPrefix("/") &&
+                  !row.id.isEmpty && !row.title.isEmpty &&
+                  (row.provider == nil || ["homebrew", "uv", "docker"].contains(row.provider!)) &&
+                  (row.allocatedBytes == nil) == (row.logicalBytes == nil) &&
+                  (row.state != .complete || row.allocatedBytes != nil) &&
+                  (row.state != .unavailable || row.allocatedBytes == nil) &&
+                  (!report.complete || row.state == .complete)
+              }) else {
+            throw InventoryDecodingError.invalidResponse
+        }
+        return report
+    }
+
+    private enum InventoryDecodingError: LocalizedError {
+        case invalidResponse
+        var errorDescription: String? {
+            "The storage overview returned an unexpected response. Scan again to refresh it."
+        }
+    }
+}
+
+/// One list combines engine-authorized cleanup with tool-owned observations.
+/// Observations never acquire a Candidate identity or enter cleanup selection.
+enum DiscoveryFinding: Identifiable {
+    case candidate(Candidate)
+    case managed(StorageInventoryReportDTO.Row)
+
+    var id: String {
+        switch self {
+        case .candidate(let item): return "candidate:" + item.id
+        case .managed(let item): return "managed:" + item.id
+        }
+    }
+    var path: String {
+        switch self {
+        case .candidate(let item): return item.path
+        case .managed(let item): return item.path
+        }
+    }
+    var title: String {
+        switch self {
+        case .candidate(let item): return item.displayName
+        case .managed(let item): return item.title
+        }
+    }
+    var allocatedBytes: UInt64? {
+        switch self {
+        case .candidate(let item): return item.measuredAllocatedBytes
+        case .managed(let item): return item.allocatedBytes
+        }
+    }
+    var modifiedNs: Int64? {
+        switch self {
+        case .candidate(let item): return item.modifiedNs
+        case .managed: return nil
+        }
+    }
+
+    static func list(candidates: [Candidate], inventory: StorageInventoryReportDTO?,
+                     filter: DiscoveryFilter, query: String, sort: DiscoverySort) -> [Self] {
+        let cleanup = candidates.filter { filter.matches($0) && $0.matchesSearch(query) }.map(Self.candidate)
+        let managed = (inventory?.rows ?? []).filter { row in
+            row.matches(filter: filter, query: query) && !candidates.contains { candidate in
+                // Suppress aggregate observations when the scanner has an exact
+                // finding within them, even when that finding is filtered out.
+                candidate.path == row.path || candidate.path.hasPrefix(row.path + "/")
+                    || row.path.hasPrefix(candidate.path + "/")
+            }
+        }.map(Self.managed)
+        let rows = cleanup + managed
+        switch sort {
+        case .suggested:
+            // Preserve the engine's ranking, then show tool-owned observations.
+            return rows
+        case .largest:
+            return rows.sorted { lhs, rhs in
+                switch (lhs.allocatedBytes, rhs.allocatedBytes) {
+                case (let l?, let r?) where l != r: return l > r
+                case (_?, nil): return true
+                case (nil, _?): return false
+                default: return lhs.path == rhs.path ? lhs.id < rhs.id : lhs.path < rhs.path
+                }
+            }
+        case .oldest:
+            return rows.sorted { lhs, rhs in
+                switch (lhs.modifiedNs, rhs.modifiedNs) {
+                case (let l?, let r?) where l != r: return l < r
+                case (_?, nil): return true
+                case (nil, _?): return false
+                default: return lhs.path == rhs.path ? lhs.id < rhs.id : lhs.path < rhs.path
+                }
+            }
+        case .name:
+            return rows.sorted { lhs, rhs in
+                let order = lhs.title.localizedStandardCompare(rhs.title)
+                return order == .orderedSame ? lhs.id < rhs.id : order == .orderedAscending
+            }
+        }
+    }
+}
+
+struct StorageInventoryStatus: View {
+    let report: StorageInventoryReportDTO?
+    let isLoading: Bool
+    let errorMessage: String?
+    let refresh: () -> Void
+    @State private var showIssues = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            if isLoading {
+                HStack(spacing: 7) {
+                    ProgressView().controlSize(.small)
+                    Text("Checking other storage locations…")
+                        .font(TeaFont.caption)
+                        .foregroundStyle(TeaTheme.inkSoft)
+                }
+                .accessibilityElement(children: .combine)
+            }
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(TeaFont.caption)
+                    .foregroundStyle(TeaTheme.rust)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+                Button("Try again", action: refresh)
+                    .buttonStyle(.plain)
+                    .font(TeaFont.captionMedium)
+                    .foregroundStyle(TeaTheme.biro)
+                    .disabled(isLoading)
+            }
+            if let report, !report.issues.isEmpty || report.omittedIssues > 0 {
+                DisclosureGroup(isExpanded: $showIssues) {
+                    VStack(alignment: .leading, spacing: 7) {
+                        ForEach(Array(report.issues.enumerated()), id: \.offset) { _, issue in
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(issue.detail)
+                                    .font(TeaFont.caption)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                Text(issue.path)
+                                    .font(TeaFont.mono)
+                                    .lineLimit(2)
+                                    .truncationMode(.middle)
+                                    .textSelection(.enabled)
+                                    .help(issue.path)
+                            }
+                        }
+                        if report.omittedIssues > 0 {
+                            Text("\(report.omittedIssues) additional entries could not be measured.")
+                                .font(TeaFont.caption)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        Button("Check again", action: refresh)
+                            .buttonStyle(.plain)
+                            .font(TeaFont.captionMedium)
+                            .foregroundStyle(TeaTheme.biro)
+                            .disabled(isLoading)
+                    }
+                    .foregroundStyle(TeaTheme.inkSoft)
+                    .padding(.top, 5)
+                } label: {
+                    Label("Some locations were not fully measured", systemImage: "info.circle")
+                        .font(TeaFont.captionMedium)
+                        .foregroundStyle(TeaTheme.rust)
+                }
+            }
+        }
+    }
+}
+
+struct StorageInventoryRowView: View {
+    let row: StorageInventoryReportDTO.Row
+    let openProvider: (ManagedProviderID) -> Void
+    @State private var expanded = false
+
+    var body: some View {
+        InkCard(padding: 9, seed: 431, fill: TeaTheme.paperDeep.opacity(0.55), stroke: TeaTheme.ink.opacity(0.25)) {
+            DisclosureGroup(isExpanded: $expanded) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(row.path)
+                        .font(TeaFont.mono)
+                        .lineLimit(3)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                        .help(row.path)
+                    if row.state == .partial {
+                        Text("Partial measurement. The total for this location is unknown.")
+                            .foregroundStyle(TeaTheme.rust)
+                    }
+                    Text(row.detail)
+                    Text(row.ownerFollowup)
+                    if let owner = row.owner {
+                        Button("Review with " + owner.title) { openProvider(owner) }
+                            .buttonStyle(.plain)
+                            .font(TeaFont.captionMedium)
+                            .foregroundStyle(TeaTheme.biro)
+                            .accessibilityHint("Opens the read-only owner review. It does not remove files.")
+                    }
+                }
+                .font(TeaFont.caption)
+                .foregroundStyle(TeaTheme.inkSoft)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 6)
+            } label: {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(row.title)
+                            .font(TeaFont.captionSemibold)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer(minLength: 3)
+                        Text(row.sizeLabel)
+                            .font(TeaFont.captionMedium)
+                            .monospacedDigit()
+                            .foregroundStyle(row.state == .complete ? TeaTheme.ink : TeaTheme.rust)
+                    }
+                    Text(row.category)
+                        .font(TeaFont.caption)
+                        .foregroundStyle(TeaTheme.inkSoft)
+                }
+                .accessibilityElement(children: .combine)
+            }
+        }
+    }
+}

--- a/native/Chippytea/Views.swift
+++ b/native/Chippytea/Views.swift
@@ -169,8 +169,14 @@ private struct ErrorBanner: View {
         InkCard(padding: 9, seed: 141, fill: TeaTheme.card, stroke: TeaTheme.rust) {
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: "exclamationmark.circle").font(TeaFont.body).foregroundStyle(TeaTheme.rust)
-                Text(message).font(TeaFont.caption).foregroundStyle(TeaTheme.ink)
-                    .textSelection(.enabled).fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 7) {
+                    Text(message).font(TeaFont.caption).foregroundStyle(TeaTheme.ink)
+                        .textSelection(.enabled).fixedSize(horizontal: false, vertical: true)
+                    if !model.rootAccessIssues.isEmpty {
+                        Button("Fix scan access…") { model.openScanLocations() }
+                            .buttonStyle(InkButtonStyle(kind: .quiet, compact: true, seed: 143))
+                    }
+                }
                 Spacer(minLength: 4)
                 Button { model.errorMessage = nil } label: {
                     Image(systemName: "xmark").font(TeaFont.caption)
@@ -845,7 +851,7 @@ private struct ScanEverywhereCTA: View {
             Button("Scan my Mac") { model.scanMyMac() }
                 .buttonStyle(InkButtonStyle(kind: .primary, fullWidth: true, seed: seed))
                 .disabled(changing)
-                .accessibilityHint("Looks through your home folder for app caches, old logs, build files and large personal files to review. Nothing is selected or removed automatically.")
+                .accessibilityHint("Finds app caches, logs, build files and personal files to review, and checks known system and developer storage locations. Nothing is removed automatically.")
             Menu {
                 Button("Projects Folder…") { model.chooseFolder(kind: "projects") }
                 Button("Downloads Folder…") { model.chooseFolder(kind: "downloads") }
@@ -947,13 +953,12 @@ private struct DiscoveryPage: View {
         if filter == .all && search.isEmpty {
             return "Nothing meets the cleanup checks yet. Small, recently changed or unverified items are left alone."
         }
-        return "No supported candidates match this view. Excluded locations stay untouched."
+        return "No findings match this view. Excluded locations stay untouched."
     }
 
-    private var candidates: [Candidate] {
-        sort.ordered(model.displayedCandidates.filter { item in
-            filter.matches(item) && item.matchesSearch(search)
-        })
+    private var findings: [DiscoveryFinding] {
+        DiscoveryFinding.list(candidates: model.displayedCandidates, inventory: model.storageInventory,
+                              filter: filter, query: search, sort: sort)
     }
 
     private var selectedItems: [Candidate] { model.displayedCandidates.filter { model.selection.contains($0.id) } }
@@ -974,27 +979,34 @@ private struct DiscoveryPage: View {
     }
 
     var body: some View {
-        let visibleCandidates = candidates
+        let visibleFindings = findings
         VStack(spacing: 0) {
             header
             if model.snapshot.roots.isEmpty {
                 FolderEmptyState(model: model)
             } else {
                 ScanStatusLine(model: model).padding(.horizontal, TeaTheme.panelPadding).padding(.bottom, 7)
-                tools(candidateCount: visibleCandidates.count).padding(.horizontal, TeaTheme.panelPadding).padding(.bottom, 8)
+                tools(findingCount: visibleFindings.count).padding(.horizontal, TeaTheme.panelPadding).padding(.bottom, 8)
                 ZStack(alignment: .bottom) {
                     ScrollView {
                         LazyVStack(spacing: 8) {
-                            if visibleCandidates.isEmpty {
+                            if visibleFindings.isEmpty && !model.inventoryLoading {
                                 EmptyState(doodle: .magnifier,
                                            title: emptyTitle,
                                            detail: emptyDetail)
                                     .padding(.top, 14)
                             } else {
-                                ForEach(Array(visibleCandidates.enumerated()), id: \.element.id) { index, item in
-                                    CandidateRow(model: model, candidate: item, seed: 241 + index * 6)
+                                ForEach(Array(visibleFindings.enumerated()), id: \.element.id) { index, finding in
+                                    switch finding {
+                                    case .candidate(let item):
+                                        CandidateRow(model: model, candidate: item, seed: 241 + index * 6)
+                                    case .managed(let row):
+                                        StorageInventoryRowView(row: row, openProvider: model.openStorageProvider)
+                                    }
                                 }
                             }
+                            StorageInventoryStatus(report: model.storageInventory, isLoading: model.inventoryLoading,
+                                errorMessage: model.inventoryError, refresh: model.refreshStorageInventory)
                         }
                         .padding(.horizontal, TeaTheme.panelPadding)
                         .padding(.top, 2)
@@ -1024,6 +1036,9 @@ private struct DiscoveryPage: View {
                           || model.discoveryPresentation.isRequestPending)
                 .help("Refresh authorised folders").accessibilityLabel("Refresh authorised folders")
             Menu {
+                Button("Scan my Mac") { model.scanMyMac() }
+                Button("Scan locations & access…") { model.openScanLocations() }
+                Divider()
                 Button("Choose Projects Folder…") { model.chooseFolder(kind: "projects") }
                 Button("Choose Downloads Folder…") { model.chooseFolder(kind: "downloads") }
                 Button("Choose Another Folder…") { model.chooseFolder(kind: "folder") }
@@ -1039,7 +1054,7 @@ private struct DiscoveryPage: View {
         .padding(.top, 8).padding(.bottom, 8)
     }
 
-    private func tools(candidateCount: Int) -> some View {
+    private func tools(findingCount: Int) -> some View {
         VStack(spacing: 7) {
             HStack(spacing: 6) {
                 ForEach(Array(DiscoveryFilter.allCases.enumerated()), id: \.element) { index, item in
@@ -1059,9 +1074,9 @@ private struct DiscoveryPage: View {
                         .buttonStyle(.plain).foregroundStyle(TeaTheme.inkSoft)
                         .accessibilityLabel("Clear filter")
                 }
-                Text(candidateCount.formatted())
+                Text(findingCount.formatted())
                     .font(TeaFont.caption).monospacedDigit().foregroundStyle(TeaTheme.inkSoft)
-                    .help("\(candidateCount) findings in this view")
+                    .help("\(findingCount) findings in this view")
                 Menu {
                     Picker("Sort", selection: $sort) {
                         ForEach(DiscoverySort.allCases, id: \.self) { Text($0.rawValue).tag($0) }
@@ -1104,8 +1119,8 @@ private struct DiscoveryPage: View {
             .disabled(!model.canEnqueueCleanup || !selectionIsCurrent)
             .accessibilityHint(deletesWithoutConfirmation
                 ? model.hasCleanupWork
-                    ? "Queues the selected developer artifacts for permanent deletion after the current cleanup. No further prompt, Trash or restore."
-                    : "Permanently deletes the selected developer artifacts without another prompt. No Trash or restore."
+                    ? "Queues the selected developer files and caches for permanent deletion after the current cleanup. No further prompt, Trash or restore."
+                    : "Permanently deletes the selected developer files and caches without another prompt. No Trash or restore."
                 : "Shows the exact selected items and consequences before cleanup.")
         }
         .padding(.horizontal, 16).padding(.top, 8).padding(.bottom, 10)
@@ -1226,7 +1241,7 @@ private struct CandidateRow: View {
                     .toggleStyle(InkCheckboxStyle(seed: seed &+ 3))
                     .padding(.top, 7)
                     .disabled(!selectionAllowed || atSelectionLimit)
-                    .help(atSelectionLimit ? "Select up to 100 items at a time." : "Select this item for cleanup")
+                    .help(candidate.cleanupBlockedReason ?? (atSelectionLimit ? "Select up to 100 items at a time." : "Select this item for cleanup"))
                     .accessibilityLabel("Select \(candidate.displayName). Path: \(candidate.path)")
                 ArtifactIcon(candidate: candidate, size: 32, seed: seed &+ 5)
                 VStack(alignment: .leading, spacing: 2) {
@@ -1237,8 +1252,12 @@ private struct CandidateRow: View {
                 }
                 Spacer(minLength: 4)
                 VStack(alignment: .trailing, spacing: 0) {
-                    Text(space(candidate.allocatedBytes)).font(TeaFont.bodyNumber).monospacedDigit()
-                    Text("estimated").font(TeaFont.caption).foregroundStyle(TeaTheme.inkSoft)
+                    if let bytes = candidate.measuredAllocatedBytes {
+                        Text(space(bytes)).font(TeaFont.bodyNumber).monospacedDigit()
+                        Text("estimated").font(TeaFont.caption).foregroundStyle(TeaTheme.inkSoft)
+                    } else {
+                        Text("Not measured").font(TeaFont.captionMedium).foregroundStyle(TeaTheme.inkSoft)
+                    }
                 }
                 .fixedSize()
             }
@@ -1441,7 +1460,7 @@ private struct ReviewTakeover: View {
                     Text(permanentEligible ? "Permanent cleanup" : "Move to Trash")
                         .font(TeaFont.bodySemibold)
                     Text(permanentEligible
-                         ? "Deletes these developer files without Trash or restore. Freed space and chips may be zero."
+                         ? "Deletes these developer files and caches without Trash or restore. Freed space and chips may be zero."
                          : "Recoverable from Activity until Trash is emptied. Moving files there does not free space or earn chips.")
                         .font(TeaFont.caption).foregroundStyle(TeaTheme.inkSoft).fixedSize(horizontal: false, vertical: true)
                 }
@@ -1480,7 +1499,7 @@ private struct ReviewTakeover: View {
                     .accessibilityHint(model.hasCleanupWork
                         ? "Queues the reviewed items to move to Trash after the current cleanup. Earns no chips."
                         : "Moves the reviewed items to Trash. Earns no chips.")
-                Text("App caches, logs, Xcode build data and personal files go to Trash only. Permanent cleanup is limited to eligible developer artifacts.")
+                Text("App caches, logs, Xcode build data and personal files go to Trash only. Verified developer files and caches can be deleted permanently.")
                     .font(TeaFont.caption).foregroundStyle(TeaTheme.inkSoft)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -1760,6 +1779,65 @@ private struct ReceiptRow: View, Equatable {
 
 // MARK: - Settings
 
+private struct ScanLocationsSection: View {
+    @ObservedObject var model: AppModel
+    private var changing: Bool { model.busy || model.hasCleanupWork || model.scanActivityForUI }
+
+    var body: some View {
+        SettingsSection(title: "Scan locations & access", seed: 377) {
+            Text("Scan your Mac’s app and developer caches, downloads and known system storage. Add other folders or mounted drives whenever you need them.")
+                .font(TeaFont.caption).foregroundStyle(TeaTheme.inkSoft)
+                .fixedSize(horizontal: false, vertical: true)
+            Button("Scan my Mac") { model.scanMyMac() }
+                .buttonStyle(InkButtonStyle(kind: .primary, fullWidth: true, compact: true, seed: 387))
+                .disabled(changing)
+            HStack(spacing: 8) {
+                Button("Redo access setup…") { model.beginDiskAccessSetup(restart: true) }
+                    .buttonStyle(InkButtonStyle(kind: .quiet, compact: true, seed: 389))
+                    .disabled(changing)
+                Spacer(minLength: 0)
+                Menu {
+                    Button("Projects Folder…") { model.chooseFolder(kind: "projects") }
+                    Button("Downloads Folder…") { model.chooseFolder(kind: "downloads") }
+                    Button("Folder or Drive…") { model.chooseFolder(kind: "folder") }
+                } label: { Text("Add folder…").font(TeaFont.captionMedium) }
+                    .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+                    .foregroundStyle(TeaTheme.biro).disabled(changing)
+            }
+            ForEach(model.snapshot.roots) { root in
+                let issue = model.rootAccessIssues.first { $0.rootId == root.id }
+                InkDivider(seed: 379)
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Image(systemName: issue == nil ? "folder" : "folder.badge.questionmark")
+                            .font(TeaFont.body).foregroundStyle(issue == nil ? TeaTheme.ink : TeaTheme.rust)
+                        Text(root.kind == "home" ? "Your files" : root.name).font(TeaFont.bodyMedium)
+                        Spacer(minLength: 0)
+                        Button { model.forgetRoot(root) } label: { Image(systemName: "minus.circle").font(TeaFont.body) }
+                            .buttonStyle(.plain).foregroundStyle(TeaTheme.inkSoft)
+                            .accessibilityLabel("Stop scanning \(root.name)")
+                            .help("Remove this scan location; files, Keep choices and history stay saved")
+                            .disabled(changing)
+                    }
+                    Text(root.path).font(TeaFont.mono).foregroundStyle(TeaTheme.inkSoft)
+                        .lineLimit(2).truncationMode(.middle).textSelection(.enabled)
+                    if let issue {
+                        Text(issue.message ?? "Folder access needs to be restored.")
+                            .font(TeaFont.caption).foregroundStyle(TeaTheme.rust)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Button(issue == nil ? "Choose this folder again…" : "Reconnect folder…") { model.reconnectRoot(root) }
+                        .buttonStyle(InkButtonStyle(kind: .quiet, compact: true, seed: 391))
+                        .disabled(changing)
+                }
+            }
+            Text("Full Disk Access lets macOS share protected files with chippytea. Some system storage still requires an administrator or its own app to manage it.")
+                .font(TeaFont.caption).foregroundStyle(TeaTheme.inkSoft)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
 private struct SettingsPage: View {
     @ObservedObject var model: AppModel
     @ObservedObject var updates: UpdateController
@@ -1767,9 +1845,11 @@ private struct SettingsPage: View {
     private var changing: Bool { model.busy || model.snapshot.cleaning || model.scanActivityForUI }
 
     var body: some View {
+        ScrollViewReader { scroll in
         ScrollView {
             VStack(alignment: .leading, spacing: 11) {
                 ScreenTitle(text: "Settings", seed: 371)
+                ScanLocationsSection(model: model).id("scan-locations")
 
                 SettingsSection(title: "App updates", seed: 372) {
                     HStack(alignment: .firstTextBaseline) {
@@ -1819,64 +1899,16 @@ private struct SettingsPage: View {
                         .disabled(systemReduceMotion)
                     InkDivider(seed: 376)
                     settingToggle(title: "Confirm before deleting",
-                                  detail: "Ask once before permanently deleting developer files.",
+                                  detail: "Ask once before permanently deleting developer files and caches.",
                                   symbol: "trash", binding: $model.confirmBeforeDeleting)
                 }
 
                 SettingsSection(title: "Owner-managed storage", seed: 393) {
                     ManagedStorageView(model: model)
-                }
+                }.id("managed-storage")
 
                 SettingsSection(title: "chippytea’s own footprint", seed: 419) {
                     StorageFootprintView(model: model)
-                }
-
-                SettingsSection(title: "Folders you’ve invited in", seed: 377) {
-                    ForEach(model.snapshot.roots) { root in
-                        HStack(spacing: 10) {
-                            Image(systemName: "folder").font(TeaFont.body).frame(width: 18)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(root.name).font(TeaFont.bodyMedium).lineLimit(1)
-                                Text(root.path).font(TeaFont.mono).foregroundStyle(TeaTheme.inkSoft)
-                                    .lineLimit(1).truncationMode(.middle).help(root.path)
-                            }
-                            Spacer(minLength: 0)
-                            Button { model.forgetRoot(root) } label: { Image(systemName: "minus.circle").font(TeaFont.body) }
-                                .buttonStyle(.plain).foregroundStyle(TeaTheme.inkSoft)
-                                .accessibilityLabel("Stop scanning \(root.name)")
-                                .help("Remove folder authorisation; files stay where they are")
-                                .disabled(changing)
-                        }
-                    }
-                    if !model.snapshot.roots.isEmpty { InkDivider(seed: 379) }
-                    if !model.homeAuthorized {
-                        Button("Scan everywhere") { model.scanMyMac() }
-                            .buttonStyle(InkButtonStyle(kind: .primary, fullWidth: true, compact: true, seed: 387))
-                            .disabled(changing)
-                            .accessibilityHint("Authorises your home folder in one step. Nothing is removed without your review.")
-                    }
-                    HStack(spacing: 8) {
-                        Button("Full Disk Access…") { model.beginDiskAccessSetup() }
-                            .buttonStyle(.plain)
-                            .font(TeaFont.captionMedium).foregroundStyle(TeaTheme.biro)
-                            .accessibilityHint("Guides you through scan access in macOS settings.")
-                            .disabled(changing)
-                        Spacer(minLength: 4)
-                        Menu {
-                            Button("Projects Folder…") { model.chooseFolder(kind: "projects") }
-                            Button("Downloads Folder…") { model.chooseFolder(kind: "downloads") }
-                            Button("Another Folder…") { model.chooseFolder(kind: "folder") }
-                        } label: {
-                            Text("Add folder…").font(TeaFont.captionMedium)
-                        }
-                        .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
-                        .foregroundStyle(TeaTheme.biro)
-                        .disabled(changing)
-                        .accessibilityLabel("Add a folder")
-                    }
-                    Text("A guided setup for a more complete scan. Optional.")
-                        .font(TeaFont.caption).foregroundStyle(TeaTheme.inkSoft)
-                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 SettingsSection(title: "Kept for a reason", seed: 381) {
@@ -1913,6 +1945,9 @@ private struct SettingsPage: View {
             .padding(.top, 8).padding(.bottom, 15)
         }
         .scrollIndicators(.hidden)
+        .onAppear { scroll.scrollTo(model.settingsSection, anchor: .top) }
+        .onChange(of: model.settingsSection) { _, section in scroll.scrollTo(section, anchor: .top) }
+        }
     }
 
     private func settingToggle(title: String, detail: String, symbol: String, binding: Binding<Bool>) -> some View {


### PR DESCRIPTION
Developer caches now appear in Find space with the same selection, review and cleanup actions as build folders. Busy caches stay visible with their reason, while installed toolchains and container storage remain review-only observations in the same list.

Folder access now offers clear reconnect, add-folder and redo-setup controls, with durable volume identities preserving valid grants across macOS device-number changes. Discovery also covers additional app caches, logs and verified Python bytecode.

Validation: all 553 Rust tests and 50 release safety tests passed on clean macOS CI. Formatting, Clippy, native app build and signature verification, update-policy checks, website build and secret scan passed. Local packaged regressions covered unified cache selection, deletion safety and folder-access recovery; native UI checks passed.
